### PR TITLE
Automate upload of new manifest data

### DIFF
--- a/crontabs/id3c-production
+++ b/crontabs/id3c-production
@@ -36,6 +36,9 @@ ENVD=/opt/backoffice/id3c-production/env.d
 # conditions.
 35 * * * * ubuntu envdir $ENVD/slack/ pipenv run id3c reportable-conditions notify --commit
 
+# Upload new manifest data
+40 * * * * ubuntu envdir $ENVD/hutch/ /opt/specimen-manifest/update-unattended
+
 # Manifests are manually uploaded periodically right now, so just check once an
 # hour at quarter 'till.
 45 * * * * ubuntu pipenv run id3c etl manifest --commit

--- a/crontabs/id3c-production
+++ b/crontabs/id3c-production
@@ -23,7 +23,7 @@ ENVD=/opt/backoffice/id3c-production/env.d
 # but ensure we process everything they might send by waiting until 20 after.
 20 * * * * ubuntu pipenv run id3c etl enrollments --commit
 
-# Kit records are created/updated from enrollment records from Audere. To ensure 
+# Kit records are created/updated from enrollment records from Audere. To ensure
 # that this doesn't run at the same time as the enrollments etl, run at 25 after.
 25 * * * * ubuntu pipenv run id3c etl kit enrollments --commit
 
@@ -32,8 +32,8 @@ ENVD=/opt/backoffice/id3c-production/env.d
 # seems good for now.
 30 * * * * ubuntu pipenv run id3c etl presence-absence --commit
 
-# After presence/absence results are uploaded, check if any contain reportable 
-# conditions. 
+# After presence/absence results are uploaded, check if any contain reportable
+# conditions.
 35 * * * * ubuntu envdir $ENVD/slack/ pipenv run id3c reportable-conditions notify --commit
 
 # Manifests are manually uploaded periodically right now, so just check once an


### PR DESCRIPTION
Automate the upload of new manifest data by adding a new cronjob that invokes the `update-unattended` script from http://github.com/seattleflu/specimen-manifests. 