### PR TITLE
science-map: Update Y2 start date to Oct 01

### DIFF
--- a/export/science-map-geojson
+++ b/export/science-map-geojson
@@ -18,7 +18,7 @@ psql --quiet --no-align --tuples-only --set ON_ERROR_STOP= <<<"
     from shipping.metadata_for_augur_build_v2
     join warehouse.tract on (tract.identifier = residence_census_tract)
 
-    where date >= '2019-09-01'
+    where date >= '2019-10-01'
       and age_category in ('child', 'adult')
       and site_category in ('clinical', 'community')
 "


### PR DESCRIPTION
We had previously set a Year 2 start date arbitrarily to September 1,
2019. Per Trevor, we want to update this start date to October 1, 2019
to "make our use of 'Y1' synonymous with the use of '2018-2019 influenza
season' by outside groups."