### PR TITLE
Suppress unknown identifier warnings for presence/absence control samples

### DIFF
--- a/crontabs/id3c-production
+++ b/crontabs/id3c-production
@@ -4,6 +4,7 @@ PATH=/usr/local/bin:/usr/bin:/bin
 # Point Pipenv at the production environment
 PIPENV_PIPFILE=/opt/backoffice/id3c-production/Pipfile
 
+LOG_CONFIG=/opt/backoffice/id3c-production/logging.yaml
 LOG_LEVEL=warning
 PGSERVICE=production-etl
 

--- a/id3c-production/logging.yaml
+++ b/id3c-production/logging.yaml
@@ -1,0 +1,40 @@
+---
+version: 1
+
+root:
+  # Filtering of messages by level is done at the handler level by using NOTSET
+  # on the root logger to emit everything.  This lets us keep console output
+  # readable while emitting verbose output to alternate handlers.
+  level: NOTSET
+  handlers:
+    - console
+    - syslog
+
+loggers:
+  # The SmartyStreets library uses urllib3, which produces DEBUG messages that
+  # can contain sensitive data.  Suppress those at its package logger.
+  urllib3:
+    level: INFO
+
+handlers:
+  console:
+    class: logging.StreamHandler
+    level: !coalesce
+      - !LOG_LEVEL
+      - INFO
+    formatter: console
+
+  # This handler emits all log levels; filtering is more usefully done by
+  # syslog itself.
+  syslog:
+    class: id3c.logging.handlers.SysLogUnixSocketHandler
+    level: NOTSET
+    formatter: syslog
+
+formatters:
+  console:
+    format: "[%(asctime)s] %(message)s"
+    datefmt: "%Y-%m-%d %H:%M:%S"
+
+  syslog:
+    format: "id3c[%(process)s] %(name)s %(levelname)s: %(message)s"

--- a/id3c-production/logging.yaml
+++ b/id3c-production/logging.yaml
@@ -16,6 +16,22 @@ loggers:
   urllib3:
     level: INFO
 
+filters:
+  unknown sample warnings for controls from id3c etl presence-absence:
+    (): id3c.logging.filters.suppress_records_matching
+    name: id3c.cli.command.etl.presence_absence
+    levelname: WARNING
+    msg:
+      pattern: Skipping results for sample without a known identifier «.+?_(Plasmid|PBS|Xeno|Water)»
+
+  unknown sample warnings for controls from id3c.db.find_identifier:
+    (): id3c.logging.filters.suppress_records_matching
+    name: id3c.db
+    funcName: find_identifier
+    levelname: WARNING
+    msg:
+      pattern: No identifier found for barcode «.+?_(Plasmid|PBS|Xeno|Water)»
+
 handlers:
   console:
     class: logging.StreamHandler
@@ -23,6 +39,9 @@ handlers:
       - !LOG_LEVEL
       - INFO
     formatter: console
+    filters:
+      - unknown sample warnings for controls from id3c etl presence-absence
+      - unknown sample warnings for controls from id3c.db.find_identifier
 
   # This handler emits all log levels; filtering is more usefully done by
   # syslog itself.


### PR DESCRIPTION
These were producing low-level but constant daily noise in our ETL jobs
and causing alerts.  If an alert is ignorable, like these, then the
alert shouldn't have happened in the first place.

Intentionally targeted very specifically so we don't suppress messages
about other unknown identifiers, or even these identifiers in other
(unexpected) contexts.

---

Requires seattleflu/id3c#106.