### PR TITLE
Start Metabase and Lab Labels services at boot

### DIFF
--- a/lab-labels/lab-labels.service
+++ b/lab-labels/lab-labels.service
@@ -9,4 +9,4 @@ ExecStart=/usr/bin/docker start -a lab-labels
 ExecStop=/usr/bin/docker stop -t 2 lab-labels
 
 [Install]
-WantedBy=local.target
+WantedBy=default.target

--- a/metabase/metabase.service
+++ b/metabase/metabase.service
@@ -9,4 +9,4 @@ ExecStart=/usr/bin/docker start -a metabase
 ExecStop=/usr/bin/docker stop -t 2 metabase
 
 [Install]
-WantedBy=local.target
+WantedBy=default.target


### PR DESCRIPTION
This was the intended behaviour, but it was thwarted by using an
incorrect, non-existent target unit name (local.target).  Whoops!

Use a standard built-in target instead!

Automatically starting services after boot is important since the
backoffice will now, if necessary, automatically reboot in the middle of
the night to apply security patches.