### PR TITLE
science-map: Update to augur build metadata v3

### DIFF
--- a/export/science-map-geojson
+++ b/export/science-map-geojson
@@ -15,10 +15,10 @@ psql --quiet --no-align --tuples-only --set ON_ERROR_STOP= <<<"
         )
     )
 
-    from shipping.metadata_for_augur_build_v2
+    from shipping.metadata_for_augur_build_v3
     join warehouse.tract on (tract.identifier = residence_census_tract)
 
     where date >= '2019-10-01'
       and age_category in ('child', 'adult')
-      and site_category in ('clinical', 'community')
+      and site_category in ('clinic', 'community', 'hospital')
 "


### PR DESCRIPTION
Update the export script for the science map to use the new version of
the augur build metadata view.

~This PR is dependent on https://github.com/seattleflu/id3c-customizations/pull/40 and will be kept as a draft until the original PR is merged.~