### PR TITLE
Add routine to terminate idle database sessions

### DIFF
--- a/bin/terminate-idle-sessions
+++ b/bin/terminate-idle-sessions
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+psql --quiet --no-align --tuples-only --set ON_ERROR_STOP= <<<"
+    with candidate_connections as (
+        select
+            pid,
+            client_addr,
+            usename,
+            application_name,
+            current_timestamp - state_change as idle_duration
+        from
+            pg_stat_activity_nonsuperuser
+        where
+                pid != pg_backend_pid()
+            and state in ('idle', 'idle in transaction', 'idle in transaction (aborted)', 'disabled')
+        order by
+            client_addr,
+            application_name,
+            state_change desc
+    )
+
+    select *, pg_terminate_backend(pid)
+    from candidate_connections
+    where idle_duration > interval '30 min'
+    and usename not in ('rdsadmin', 'metabase')
+    and usename not in (select rolname from pg_roles where rolsuper = 'f')
+    and pg_terminate_backend(pid) = 't'
+"

--- a/bin/terminate-idle-sessions
+++ b/bin/terminate-idle-sessions
@@ -23,6 +23,6 @@ psql --quiet --no-align --tuples-only --set ON_ERROR_STOP= <<<"
     from candidate_connections
     where idle_duration > interval '30 min'
     and usename not in ('rdsadmin', 'metabase')
-    and usename not in (select rolname from pg_roles where rolsuper = 'f')
-    and pg_terminate_backend(pid) = 't'
+    and usename not in (select rolname from pg_roles where rolsuper)
+    and pg_terminate_backend(pid) = 'f'
 "

--- a/bin/terminate-idle-sessions
+++ b/bin/terminate-idle-sessions
@@ -17,12 +17,15 @@ psql --quiet --no-align --tuples-only --set ON_ERROR_STOP= <<<"
             client_addr,
             application_name,
             state_change desc
+    ),
+
+    idle_sessions as (
+        select *, pg_terminate_backend(pid) as terminated
+        from candidate_connections
+        where idle_duration > interval '30 min'
+        and usename not in ('rdsadmin', 'metabase')
+        and usename not in (select rolname from pg_roles where rolsuper)
     )
 
-    select *, pg_terminate_backend(pid)
-    from candidate_connections
-    where idle_duration > interval '30 min'
-    and usename not in ('rdsadmin', 'metabase')
-    and usename not in (select rolname from pg_roles where rolsuper)
-    and pg_terminate_backend(pid) = 'f'
+    select * from idle_sessions where not terminated
 "

--- a/crontabs/id3c-production
+++ b/crontabs/id3c-production
@@ -63,3 +63,6 @@ ENVD=/opt/backoffice/id3c-production/env.d
 0-50/10 * * * * ubuntu flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-kiosk pipenv run id3c etl redcap-det kiosk --commit
 5-55/10 * * * * ubuntu flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-swab-n-send pipenv run id3c etl redcap-det swab-n-send --commit
 3-58/5  * * * * ubuntu pipenv run id3c etl fhir --commit
+
+# Run the idle database session disconnector routine every minute
+* * * * * ubuntu /opt/backoffice/bin/terminate-idle-sessions


### PR DESCRIPTION
Add a crontab that runs every minute to terminate idle database sessions
other than those of superusers, the `rdsadmin` and the `metabase` roles
that have been idle for more than 30 minutes.