### PR TITLE
upload-sch-retrospective-data-pulls: Use .xls instead of .csv

### DIFF
--- a/bin/upload-sch-retrospective-data-pulls
+++ b/bin/upload-sch-retrospective-data-pulls
@@ -5,6 +5,7 @@
 #
 
 set -euo pipefail
+shopt -s extglob
 
 # Change to the top-level of the backoffice checkout
 cd "$(dirname "$0")/.."
@@ -48,17 +49,22 @@ main() {
     # Do not include SFS Year2 Main Data files prior to 2020. After the last
     # SCH data upload of 2019, the column naming scheme changed. The CLI command
     # was then changed, now causing earlier data pulls to fail on parsing.
+
+    # Since the 2020-02-10 dataset, Amanda has only sent us Excel workbooks,
+    # but preserve support for CSV too.
     aws s3 cp --recursive \
         s3://fh-pi-bedford-t/seattleflu/sch/ \
         "$datadir" \
         --exclude "*" \
         --include "SFS_Year2_Main_Data_2020*.csv" \
+        --include "SFS_Year2_Main_Data_2020*.xls" \
+        --include "SFS_Year2_Main_Data_2020*.xlsx" \
         --include "SFS_Year2_Main_Data_2020*.ndjson"
     echo
 
-    for retrospective_csv_file in "$datadir"/*.csv
+    for retrospective_spreadsheet_file in "$datadir"/*.@(csv|xls|xlsx)
     do
-        retrospective_ndjson_file="${retrospective_csv_file%.csv}.ndjson"
+        retrospective_ndjson_file="${retrospective_spreadsheet_file%.@(csv|xls|xlsx)}.ndjson"
 
         echo "Checking for parsed retrospective data «$retrospective_ndjson_file»"
         if [[ -e "$retrospective_ndjson_file" ]]; then
@@ -69,7 +75,7 @@ main() {
 
         echo "No parsed data found. Parsing now"
         echo
-        if ! $id3c clinical parse-sch "$retrospective_csv_file" > "$retrospective_ndjson_file"; then
+        if ! $id3c clinical parse-sch "$retrospective_spreadsheet_file" > "$retrospective_ndjson_file"; then
             echo "Something went wrong when parsing the retrospective data"
             exit 1
         fi

--- a/bin/upload-sch-retrospective-data-pulls
+++ b/bin/upload-sch-retrospective-data-pulls
@@ -49,6 +49,7 @@ main() {
     # Do not include SFS Year2 Main Data files prior to 2020. After the last
     # SCH data upload of 2019, the column naming scheme changed. The CLI command
     # was then changed, now causing earlier data pulls to fail on parsing.
+    glob_pattern="SFS_Year2_Main_Data_2020*"
 
     # Since the 2020-02-10 dataset, Amanda has only sent us Excel workbooks,
     # but preserve support for CSV too.
@@ -56,10 +57,10 @@ main() {
         s3://fh-pi-bedford-t/seattleflu/sch/ \
         "$datadir" \
         --exclude "*" \
-        --include "SFS_Year2_Main_Data_2020*.csv" \
-        --include "SFS_Year2_Main_Data_2020*.xls" \
-        --include "SFS_Year2_Main_Data_2020*.xlsx" \
-        --include "SFS_Year2_Main_Data_2020*.ndjson"
+        --include "$glob_pattern.csv" \
+        --include "$glob_pattern.xls" \
+        --include "$glob_pattern.xlsx" \
+        --include "$glob_pattern.ndjson"
     echo
 
     for retrospective_spreadsheet_file in "$datadir"/*.@(csv|xls|xlsx)


### PR DESCRIPTION
Amanda is not longer sending us retrospective SCH data in CSV format.
When running the automated `upload-sch-retrospective-data-pulls` script,
check for `.xls` file extensions instead of `.csv`.

-------

Depends on https://github.com/seattleflu/id3c-customizations/pull/53