### PR TITLE
Add routine to terminate old metabase sessions

### DIFF
--- a/bin/terminate-old-metabase-sessions
+++ b/bin/terminate-old-metabase-sessions
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+psql --quiet --no-align --tuples-only --set ON_ERROR_STOP= <<<"
+    with active_metabase_connections as (
+        select
+            pid,
+            current_timestamp - state_change as active_duration
+        from
+            pg_stat_activity_nonsuperuser
+        where
+            pid != pg_backend_pid()
+            and usename = 'metabase'
+            and state = 'active'
+        order by
+            active_duration desc
+    ),
+
+    old_sessions as (
+        select *, pg_terminate_backend(pid) as terminated
+        from active_metabase_connections
+        where active_duration > interval '10 min'
+    )
+
+    select * from idle_sessions where not terminated
+"

--- a/crontabs/id3c-production
+++ b/crontabs/id3c-production
@@ -83,3 +83,5 @@ ENVD=/opt/backoffice/id3c-production/env.d
 
 # Run the idle database session disconnector routine every minute
 * * * * * ubuntu /opt/backoffice/bin/terminate-idle-sessions
+# Run the old metabase session disconnector routine every minute
+* * * * * ubuntu /opt/backoffice/bin/terminate-old-metabase-sessions


### PR DESCRIPTION
Add a crontab that runs every minute to terminate old metabase sessions that have been active for more than 10 minutes.

10 was an arbitrary number, we can change the interval if we need to. 