### PR TITLE
refresh-database: Prevent loading of psqlrc files

### DIFF
--- a/dev/refresh-database
+++ b/dev/refresh-database
@@ -81,7 +81,7 @@ main() {
 
         log "Filtering to non-login production roles which aren't internal to Pg or RDS"
 
-        production psql --quiet --no-align --tuples-only <<<"
+        production psql --quiet --no-psqlrc --no-align --tuples-only <<<"
             select rolname
               from pg_roles
              where not rolcanlogin
@@ -104,7 +104,7 @@ main() {
     createdb --encoding=UTF-8 "$PGDATABASE"
 
     log "Restoring filtered roles"
-    psql < production-roles-filtered.sql |& suppress-ignorable-errors
+    psql --no-psqlrc < production-roles-filtered.sql |& suppress-ignorable-errors
 
     log "Restoring database dump"
     pg_restore --dbname "$PGDATABASE" production.pgdb |& suppress-ignorable-errors || true


### PR DESCRIPTION
Avoids errors and unexpected settings within these user-specific
preference files; should be a standard thing we do for batch jobs using
psql.

For example, I recently added "\set ON_ERROR_STOP=1" to my ~/.psqlrc so
interactive psql sessions had better error-handling behaviour for
multiline inputs, but this broke refresh-database, which expected errors
to be ignored by default.