### PR TITLE
crontabs: reportable conditions

### DIFF
--- a/crontabs/id3c-production
+++ b/crontabs/id3c-production
@@ -30,6 +30,10 @@ ENVD=/opt/backoffice/id3c-production/env.d
 # Test results are pushed at arbitrary times now, so check for new ones every 15m.
 */15 * * * * ubuntu pipenv run id3c etl presence-absence --commit
 
+# 5 minutes after presence/absence results are uploaded,
+# check if any contain reportable conditions.
+5-50/15 * * * * ubuntu envdir $ENVD/slack pipenv run id3c reportable-conditions notify --commit
+
 # Upload new manifest data
 40 * * * * ubuntu chronic envdir $ENVD/hutch/ /opt/specimen-manifests/update-unattended --push-and-upload
 


### PR DESCRIPTION
Run 5 minutes after presence/absence results are uploaded to check
if any contain reportable conditions.