### PR TITLE
Generate lab result report PDFs for SCAN 

### DIFF
--- a/bin/scan-return-of-results/generate-pdfs
+++ b/bin/scan-return-of-results/generate-pdfs
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+: "${S3_PREFIX:=s3://dokku-stack-phi/covid19/scan-study-inbound}"
+
+params="${1:-$S3_PREFIX/scan_return_results.csv}"
+output="${2:-$S3_PREFIX/{qrcode\}-{birth_date\}-en.pdf}"
+
+docker run \
+    --rm \
+    --interactive \
+    --env=AWS_ACCESS_KEY_ID \
+    --env=AWS_SECRET_ACCESS_KEY \
+    seattleflu/lab-result-reports:build-4 \
+        fill-template \
+            --template scan/report-en.tex \
+            --params "$params" \
+            --output "$output" \
+            --filter 'status_code not in ["not-received", "pending"]'

--- a/bin/scan-return-of-results/transform
+++ b/bin/scan-return-of-results/transform
@@ -28,6 +28,7 @@ def parse_redcap(redcap_file) -> pd.DataFrame:
     # For example, if the two participant-entered barcodes don't match, we
     # could nullify and ignore both of them instead of blowing up with an
     # error.
+    assert all(redcap_data['birth_date'].str.match(r"^\d{4}-\d{2}-\d{2}$").dropna())
     assert all((redcap_data['pre_scan_barcode'] == redcap_data['return_utm_barcode']).dropna())
     assert all((redcap_data['utm_tube_barcode_2'] == redcap_data['reenter_barcode']).dropna())
 

--- a/bin/scan-return-of-results/transform
+++ b/bin/scan-return-of-results/transform
@@ -47,7 +47,7 @@ def parse_redcap(redcap_file) -> pd.DataFrame:
 
 
 def normalize_barcode(barcode):
-    return barcode.str.lower().str.strip()
+    return barcode.str.upper().str.strip()
 
 
 def edit_status_code(scan_data: pd.DataFrame) -> pd.DataFrame:

--- a/crontabs/uw-lab-med-return-of-results
+++ b/crontabs/uw-lab-med-return-of-results
@@ -13,3 +13,4 @@ ENVD=/opt/backoffice/id3c-production/env.d
 
 # Export the latest, parsed SCAN return of results data to S3 for UW Lab Med's results portal
 35 * * * * ubuntu pipenv run envdir $ENVD/redcap-scan/ /opt/backoffice/bin/scan-return-of-results/workflow-scan-lab-med | envdir $ENVD/securelink/ aws s3 cp - s3://dokku-stack-phi/covid19/scan-study-inbound/scan_return_results.csv
+40 * * * * ubuntu chronic envdir $ENVD/securelink /opt/backoffice/bin/scan-return-of-results/generate-pdfs


### PR DESCRIPTION
This is the backoffice cronjob to generate PDFs. Most of the actual PDF generation code lives in https://github.com/seattleflu/lab-result-reports.