### PR TITLE
Mask a known barcode mismatch in SCAN return of results processing

### DIFF
--- a/bin/scan-return-of-results/export-redcap-scan
+++ b/bin/scan-return-of-results/export-redcap-scan
@@ -8,7 +8,7 @@ set -euo pipefail
 : "${REDCAP_API_URL:?The REDCAP_API_URL environment variable is required.}"
 : "${REDCAP_API_TOKEN:?The REDCAP_API_TOKEN environment variable is required.}"
 
-fields="participant_first_name,participant_last_name,birthday,pre_scan_barcode,utm_tube_barcode_2,reenter_barcode,return_utm_barcode,contacted"
+fields="record_id,participant_first_name,participant_last_name,birthday,pre_scan_barcode,utm_tube_barcode_2,reenter_barcode,return_utm_barcode,contacted"
 filters="[participant_first_name] != '' and [participant_last_name] != '' and [birthday] != ''"
 
 curl -fsSL -H "Content-Type: application/x-www-form-urlencoded" \

--- a/bin/scan-return-of-results/transform
+++ b/bin/scan-return-of-results/transform
@@ -28,6 +28,10 @@ def parse_redcap(redcap_file) -> pd.DataFrame:
     # For example, if the two participant-entered barcodes don't match, we
     # could nullify and ignore both of them instead of blowing up with an
     # error.
+    #
+    # Known errors are masked, for now at least.
+    redcap_data.loc[redcap_data['record_id'] == '210', 'pre_scan_barcode'] = pd.NA
+
     assert all((redcap_data['pre_scan_barcode'] == redcap_data['return_utm_barcode']).dropna())
     assert all((redcap_data['utm_tube_barcode_2'] == redcap_data['reenter_barcode']).dropna())
 


### PR DESCRIPTION
Thinking is that we'd still want to catch mismatches for manual review
on subsequent issues.  And we can still relax the assertions further in
the future, if needed.

Masks by REDCap record id to avoid leaking the barcode itself.