### PR TITLE
scan-return-of-results: Don't make PDFs on "never-tested"

### DIFF
--- a/bin/scan-return-of-results/generate-pdfs
+++ b/bin/scan-return-of-results/generate-pdfs
@@ -14,4 +14,4 @@ docker run \
             --template scan/report-en.tex \
             --params "$params" \
             --output "$output" \
-            --filter 'status_code not in ["not-received", "pending"]'
+            --filter 'status_code not in ["not-received", "never-tested", "pending"]'


### PR DESCRIPTION
Add "never-tested" to the list of excluded barcodes in PDF generation.