### PR TITLE
Generate PDFs for es, vi, zh-Hans

### DIFF
--- a/bin/scan-return-of-results/generate-pdfs
+++ b/bin/scan-return-of-results/generate-pdfs
@@ -5,7 +5,7 @@ params="${1:-s3://dokku-stack-phi/covid19/scan-study-inbound/scan_return_results
 output="${2:-s3://dokku-stack-phi/covid19/results-scan-study/{qrcode\}-{birth_date\}}"
 
 for lang in "en" "es" "vi" "zh-Hans"; do
-    echo "Generating PDFs for language code «$lang»"
+    echo "Generating PDFs for language code «${lang}»"
 
     docker run \
         --rm \

--- a/bin/scan-return-of-results/generate-pdfs
+++ b/bin/scan-return-of-results/generate-pdfs
@@ -2,10 +2,10 @@
 set -euo pipefail
 
 params="${1:-s3://dokku-stack-phi/covid19/scan-study-inbound/scan_return_results.csv}"
+output="${2:-s3://dokku-stack-phi/covid19/results-scan-study/{qrcode\}-{birth_date\}}"
 
 for lang in "en" "es" "vi" "zh-Hans"; do
     echo "Generating PDFs for language code «$lang»"
-    output="${2:-s3://dokku-stack-phi/covid19/results-scan-study/{qrcode\}-{birth_date\}-$lang.pdf}"
 
     docker run \
         --rm \
@@ -17,6 +17,6 @@ for lang in "en" "es" "vi" "zh-Hans"; do
             fill-template \
                 --template "scan/report-$lang.tex" \
                 --params "$params" \
-                --output "$output" \
+                --output "$output-$lang.pdf" \
                 --filter 'status_code not in ["not-received", "pending"]'
 done;

--- a/bin/scan-return-of-results/generate-pdfs
+++ b/bin/scan-return-of-results/generate-pdfs
@@ -2,17 +2,21 @@
 set -euo pipefail
 
 params="${1:-s3://dokku-stack-phi/covid19/scan-study-inbound/scan_return_results.csv}"
-output="${2:-s3://dokku-stack-phi/covid19/results-scan-study/{qrcode\}-{birth_date\}-en.pdf}"
 
-docker run \
-    --rm \
-    --interactive \
-    --env=AWS_ACCESS_KEY_ID \
-    --env=AWS_SECRET_ACCESS_KEY \
-    --env=LOG_LEVEL \
-    seattleflu/lab-result-reports:build-8 \
-        fill-template \
-            --template scan/report-en.tex \
-            --params "$params" \
-            --output "$output" \
-            --filter 'status_code not in ["not-received", "pending"]'
+for lang in "en" "es" "vi" "zh-Hans"; do
+    echo "Generating PDFs for language code «$lang»"
+    output="${2:-s3://dokku-stack-phi/covid19/results-scan-study/{qrcode\}-{birth_date\}-$lang.pdf}"
+
+    docker run \
+        --rm \
+        --interactive \
+        --env=AWS_ACCESS_KEY_ID \
+        --env=AWS_SECRET_ACCESS_KEY \
+        --env=LOG_LEVEL \
+        seattleflu/lab-result-reports:build-9 \
+            fill-template \
+                --template "scan/report-$lang.tex" \
+                --params "$params" \
+                --output "$output" \
+                --filter 'status_code not in ["not-received", "pending"]'
+done;


### PR DESCRIPTION
Generate PDFs for three additional finalized languages: Spanish,
Vietnamese, and Chinese (simplified).

Use the latest Docker image for PDF generation.
