### PR TITLE
Add zh-Hant to list of languages to export

### DIFF
--- a/bin/scan-return-of-results/generate-pdfs
+++ b/bin/scan-return-of-results/generate-pdfs
@@ -46,7 +46,7 @@ main() {
             --env=LOG_LEVEL \
             --user "$(id -u):$(id -g)" \
             "${mounts[@]}" \
-            seattleflu/lab-result-reports:build-11 \
+            seattleflu/lab-result-reports:build-14 \
                 fill-template \
                     --template "scan/report-$lang.tex" \
                     --params "$params" \

--- a/bin/scan-return-of-results/generate-pdfs
+++ b/bin/scan-return-of-results/generate-pdfs
@@ -35,7 +35,7 @@ main() {
         debug
     fi
 
-    for lang in "en" "es" "vi" "zh-Hans"; do
+    for lang in "en" "es" "vi" "zh-Hans" "zh-Hant"; do
         debug "Generating PDFs for language code «${lang}»"
 
         docker run \
@@ -46,7 +46,7 @@ main() {
             --env=LOG_LEVEL \
             --user "$(id -u):$(id -g)" \
             "${mounts[@]}" \
-            seattleflu/lab-result-reports:build-10 \
+            seattleflu/lab-result-reports:build-11 \
                 fill-template \
                     --template "scan/report-$lang.tex" \
                     --params "$params" \

--- a/bin/scan-return-of-results/generate-results-csv
+++ b/bin/scan-return-of-results/generate-results-csv
@@ -34,6 +34,7 @@ export-redcap-data() {
     REDCAP_API_TOKEN="$REDCAP_API_TOKEN_ES" ./export-redcap-scan | tail -n +2
     REDCAP_API_TOKEN="$REDCAP_API_TOKEN_VI" ./export-redcap-scan | tail -n +2
     REDCAP_API_TOKEN="$REDCAP_API_TOKEN_ZH_HANS" ./export-redcap-scan | tail -n +2
+    REDCAP_API_TOKEN="$REDCAP_API_TOKEN_ZH_HANT" ./export-redcap-scan | tail -n +2
 }
 
 print-help() {

--- a/crontabs/id3c-production
+++ b/crontabs/id3c-production
@@ -82,6 +82,7 @@ ENVD=/opt/backoffice/id3c-production/env.d
 7,37 * * * * ubuntu flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-scan-es pipenv run id3c etl redcap-det scan-es --commit
 9,39 * * * * ubuntu flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-scan-vi pipenv run id3c etl redcap-det scan-vi --commit
 11,41 * * * * ubuntu flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-scan-zh-Hans pipenv run id3c etl redcap-det scan-zh-Hans --commit
+13,43 * * * * ubuntu flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-scan-zh-Hant pipenv run id3c etl redcap-det scan-zh-Hant --commit
 
 # Ingest FHIR documents every 5 minutes.
 */5  * * * * ubuntu pipenv run id3c etl fhir --commit


### PR DESCRIPTION
Add traditional Chinese (zh-Hant) to the list of REDCap project
languages we iterate over to export SCAN participant results. Use the
latest Docker image build that includes traditional Chinese.