### PR TITLE
crontabs: increase frequency of manifest jobs

### DIFF
--- a/crontabs/id3c-production
+++ b/crontabs/id3c-production
@@ -34,8 +34,10 @@ ENVD=/opt/backoffice/id3c-production/env.d
 # check if any contain reportable conditions.
 5-50/15 * * * * ubuntu envdir $ENVD/slack pipenv run id3c reportable-conditions notify --commit
 
-# Upload new manifest data
-40 * * * * ubuntu chronic envdir $ENVD/hutch/ /opt/specimen-manifests/update-unattended --push-and-upload
+# Manifest is uploaded to AWS at arbitrary times now, so check for new records every 10m.
+# This is often the blocker for the presence/absence ETl, so run more frequently than
+# the presence/absence ETL to avoid extended delay of results.
+*/10 * * * * ubuntu chronic envdir $ENVD/hutch/ /opt/specimen-manifests/update-unattended --push-and-upload
 
 # Upload new UW retrospectives to REDCap once a day at midnight
 0 0 * * * ubuntu pipenv run chronic envdir $ENVD/hutch/ envdir $ENVD/redcap-uw-retrospectives/ /opt/backoffice/bin/import-uw-retrospectives-to-redcap --import
@@ -43,9 +45,8 @@ ENVD=/opt/backoffice/id3c-production/env.d
 # Create and upload REDCap DETs for UW retrospectives once a day at 4 A.M.
 0 4 * * * ubuntu pipenv run chronic envdir $ENVD/redcap-uw-retrospectives/ /opt/backoffice/bin/generate-and-upload-uw-retro-redcap-dets
 
-# Manifests are manually uploaded periodically right now, so just check once an
-# hour at quarter 'till.
-45 * * * * ubuntu pipenv run id3c etl manifest --commit
+# Run the manifest ETL 5 minutes after new manifest records are uploaded
+5-55/10 * * * * ubuntu pipenv run id3c etl manifest --commit
 
 # Kit records are created/updated from manifest records. To ensure that this
 # doesn't run at the same time as manifest etl, run ten 'till.


### PR DESCRIPTION
The manifest parse/upload/ingest is often the blocker for the ingest
of presence/absence results. Increase the frequency of the manifest
jobs to avoid extended delay of results.