### PR TITLE
Group enroll redcap dets

### DIFF
--- a/bin/generate-and-upload-group-enrollment-redcap-dets
+++ b/bin/generate-and-upload-group-enrollment-redcap-dets
@@ -1,0 +1,55 @@
+#!/bin/bash
+# usage: ./bin/generate-and-upload-group-enrollment-redcap-dets
+#
+# Generates group enrollment (an event type) REDCap DETs from the SCAN IRB
+# REDCap projects for records that have been created and/or modified since
+# 25 hours ago and uploads them to ID3C.
+#
+
+set -euo pipefail
+
+# Check this early before we do any work rather than failing at the end.
+: "${REDCAP_API_URL:?The environment variable REDCAP_API_URL is required.}"
+
+# Absolute path to our containing repo
+base="$(cd "$(dirname "$0")/.."; pwd)"
+
+
+main() {
+    for arg; do
+        case "$arg" in
+            -h|--help)
+                print-help
+                exit 0;;
+        esac
+    done
+    upload-to-id3c <(generate-redcap-dets)
+}
+
+generate-redcap-dets() {
+    REDCAP_API_TOKEN="$REDCAP_API_TOKEN_IRB_EN" id3c redcap-det generate --project-id 22461 --event "group_enroll_arm_4" --since-date "`date +"%F %T" -d "25 hours ago"`" --include-incomplete
+    REDCAP_API_TOKEN="$REDCAP_API_TOKEN_IRB_ES" id3c redcap-det generate --project-id 22475 --event "group_enroll_arm_4" --since-date "`date +"%F %T" -d "25 hours ago"`" --include-incomplete
+    REDCAP_API_TOKEN="$REDCAP_API_TOKEN_IRB_ZH_HANT" id3c redcap-det generate --project-id 22474 --event "group_enroll_arm_4" --since-date "`date +"%F %T" -d "25 hours ago"`" --include-incomplete
+}
+
+upload-to-id3c() {
+    id3c redcap-det upload "$1"
+}
+
+print-help() {
+    # Print the help comments at the top of this file ($0)
+    local line
+    while read -r line; do
+        if [[ $line =~ ^#! ]]; then
+            continue
+        elif [[ $line =~ ^# ]]; then
+            line="${line/##/}"
+            line="${line/# /}"
+            echo "$line"
+        else
+            break
+        fi
+    done < "$0"
+}
+
+main "$@"

--- a/crontabs/id3c-production
+++ b/crontabs/id3c-production
@@ -40,6 +40,9 @@ XDG_RUNTIME_DIR=/home/ubuntu/run
 # Create and upload REDCap DETs for UW retrospectives once a day at 4 A.M.
 0 4 * * * ubuntu pipenv run chronic envdir $ENVD/redcap-uw-retrospectives/ generate-and-upload-uw-retro-redcap-dets
 
+# Create and upload REDCap DETs for SCAN IRB group enrollments once an hour at a quarter past.
+15 */1 * * * ubuntu pipenv run chronic envdir $ENVD/redcap-scan/ generate-and-group-enrollment-redcap-dets
+
 # Run the manifest ETL 5 minutes after new manifest records are uploaded
 5-55/10 * * * * ubuntu fatigue --quiet pipenv run id3c etl manifest --commit
 

--- a/crontabs/id3c-production
+++ b/crontabs/id3c-production
@@ -22,14 +22,6 @@ XDG_RUNTIME_DIR=/home/ubuntu/run
 # Genomes are uploaded irregularly.  Once an hour should be good for now.
 10 * * * * ubuntu pipenv run id3c etl consensus-genome --commit
 
-# Audere sends us data at quarter past.  It rarely takes more than a minute,
-# but ensure we process everything they might send by waiting until 20 after.
-20 * * * * ubuntu pipenv run id3c etl enrollments --commit
-
-# Kit records are created/updated from enrollment records from Audere. To ensure
-# that this doesn't run at the same time as the enrollments etl, run at 25 after.
-25 * * * * ubuntu pipenv run id3c etl kit enrollments --commit
-
 # Test results are pushed at arbitrary times now, so check for new ones every 15m.
 */15 * * * * ubuntu fatigue --quiet pipenv run id3c etl presence-absence --commit
 


### PR DESCRIPTION
Create a cron job that uploads "fake" REDCap DETs for SCAN IRB group enrollment data. 
Schedule it for once an hour. 

Depends on https://github.com/seattleflu/id3c/pull/156