### PR TITLE
Return of results processing for SCAN kiosk/in-person enrollments

### DIFF
--- a/bin/scan-return-of-results/export-redcap-scan
+++ b/bin/scan-return-of-results/export-redcap-scan
@@ -10,8 +10,9 @@ from typing import NamedTuple, Optional
 
 
 REDCAP_API_URL = environ["REDCAP_API_URL"]
-REDCAP_API_TOKEN = lambda lang: environ[(
-    ("REDCAP_API_TOKEN_IRB_%s" % lang)
+REDCAP_API_TOKEN = lambda lang, collection_via: environ[((
+    "REDCAP_API_TOKEN_IRB_%s" % lang if collection_via == "mail" else
+    "REDCAP_API_TOKEN_IRB_%s_%s" % (collection_via, lang))
         .upper()
         .replace("-", "_")
 )]
@@ -23,6 +24,7 @@ FIELDS = [
     "birthday",
     "utm_tube_barcode_2",
     "reenter_barcode",
+    "reenter_barcode_2",
     "return_utm_barcode",
     "contacted",
 ]
@@ -36,18 +38,23 @@ REQUIRED_FIELDS = [
 
 class ScanProject(redcap.Project):
     lang: str
+    collection_via: str
 
-    def __init__(self, project_id: str, lang: str) -> None:
-        super().__init__(REDCAP_API_URL, REDCAP_API_TOKEN(lang), project_id)
+    def __init__(self, project_id: str, lang: str, collection_via: str) -> None:
+        super().__init__(REDCAP_API_URL, REDCAP_API_TOKEN(lang, collection_via), project_id)
         self.lang = lang
+        self.collection_via = collection_via
 
 
 def main():
     projects = [
         # SCAN (research study)
-        ScanProject(22461, "en"),
-        ScanProject(22475, "es"),
-        ScanProject(22474, "zh-Hant"),
+        ScanProject(22461, "en", "mail"),
+        ScanProject(22475, "es", "mail"),
+        ScanProject(22474, "zh-Hant", "mail"),
+
+        # SCAN kiosks
+        ScanProject(23089, "en", "kiosk"),
     ]
 
     for project_records in map(fetch_records, projects):
@@ -60,7 +67,10 @@ def fetch_records(project):
         if not all(len(record[field]) for field in REQUIRED_FIELDS):
             continue
 
-        yield record
+        yield {
+            "project_collection_via": project.collection_via,
+            **record,
+        }
 
 
 if __name__ == "__main__":

--- a/bin/scan-return-of-results/export-redcap-scan
+++ b/bin/scan-return-of-results/export-redcap-scan
@@ -1,7 +1,7 @@
 #!/bin/bash
 # usage: export-redcap-scan
 #
-# Exports participant information from the SCAN REDCap projects as CSV.
+# Exports participant information from the SCAN REDCap projects as NDJSON.
 #
 set -euo pipefail
 
@@ -15,11 +15,12 @@ curl -fsSL -H "Content-Type: application/x-www-form-urlencoded" \
       -H "Accept: application/json" \
       -X POST \
       -d @<(echo "token=$REDCAP_API_TOKEN") \
-      -d format=csv \
+      -d format=json \
       -d content=record \
       -d type=flat \
       -d fields="$fields" \
       -d filterLogic="$filters" \
       -d exportDataAccessGroups=false \
       -d returnFormat=json \
-      "$REDCAP_API_URL"
+      "$REDCAP_API_URL" \
+| jq --compact-output '.[]'

--- a/bin/scan-return-of-results/export-redcap-scan
+++ b/bin/scan-return-of-results/export-redcap-scan
@@ -1,26 +1,67 @@
-#!/bin/bash
+#!/usr/bin/env python3
 # usage: export-redcap-scan
 #
 # Exports participant information from the SCAN REDCap projects as NDJSON.
 #
-set -euo pipefail
+import json
+from id3c.cli import redcap
+from os import environ
+from typing import NamedTuple, Optional
 
-: "${REDCAP_API_URL:?The REDCAP_API_URL environment variable is required.}"
-: "${REDCAP_API_TOKEN:?The REDCAP_API_TOKEN environment variable is required.}"
 
-fields="record_id,participant_first_name,participant_last_name,birthday,pre_scan_barcode,utm_tube_barcode_2,reenter_barcode,return_utm_barcode,contacted"
-filters="[participant_first_name] != '' and [participant_last_name] != '' and [birthday] != ''"
+REDCAP_API_URL = environ["REDCAP_API_URL"]
+REDCAP_API_TOKEN = lambda lang: environ[(
+    ("REDCAP_API_TOKEN_IRB_%s" % lang)
+        .upper()
+        .replace("-", "_")
+)]
 
-curl -fsSL -H "Content-Type: application/x-www-form-urlencoded" \
-      -H "Accept: application/json" \
-      -X POST \
-      -d @<(echo "token=$REDCAP_API_TOKEN") \
-      -d format=json \
-      -d content=record \
-      -d type=flat \
-      -d fields="$fields" \
-      -d filterLogic="$filters" \
-      -d exportDataAccessGroups=false \
-      -d returnFormat=json \
-      "$REDCAP_API_URL" \
-| jq --compact-output '.[]'
+FIELDS = [
+    "record_id",
+    "participant_first_name",
+    "participant_last_name",
+    "birthday",
+    "utm_tube_barcode_2",
+    "reenter_barcode",
+    "return_utm_barcode",
+    "contacted",
+]
+
+REQUIRED_FIELDS = [
+    "participant_first_name",
+    "participant_last_name",
+    "birthday",
+]
+
+
+class ScanProject(redcap.Project):
+    lang: str
+
+    def __init__(self, project_id: str, lang: str) -> None:
+        super().__init__(REDCAP_API_URL, REDCAP_API_TOKEN(lang), project_id)
+        self.lang = lang
+
+
+def main():
+    projects = [
+        # SCAN (research study)
+        ScanProject(22461, "en"),
+        ScanProject(22475, "es"),
+        ScanProject(22474, "zh-Hant"),
+    ]
+
+    for project_records in map(fetch_records, projects):
+        for record in project_records:
+            print(json.dumps(record, indent = None, separators = ",:"), flush = True)
+
+
+def fetch_records(project):
+    for record in project.records(fields = FIELDS, raw = True):
+        if not all(len(record[field]) for field in REQUIRED_FIELDS):
+            continue
+
+        yield record
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/scan-return-of-results/generate-pdfs
+++ b/bin/scan-return-of-results/generate-pdfs
@@ -50,7 +50,7 @@ main() {
             --env=LOG_LEVEL \
             --user "$(id -u):$(id -g)" \
             "${mounts[@]}" \
-            seattleflu/lab-result-reports:build-21 \
+            seattleflu/lab-result-reports:build-22 \
                 fill-template \
                     --template "scan-irb/report-$lang.tex" \
                     --params "$params" \

--- a/bin/scan-return-of-results/generate-results-csv
+++ b/bin/scan-return-of-results/generate-results-csv
@@ -23,14 +23,7 @@ main() {
     # Change to the ./bin/scan-return-of-results directory in the backoffice checkout
     cd "$(dirname "$0")"
 
-    ./transform <(export-redcap-data) <(./export-id3c-scan-return-results)
-}
-
-# Exports data for all REDCap projects as one NDJSON stream.
-export-redcap-data() {
-    REDCAP_API_TOKEN="$REDCAP_API_TOKEN_IRB_EN" ./export-redcap-scan
-    REDCAP_API_TOKEN="$REDCAP_API_TOKEN_IRB_ES" ./export-redcap-scan
-    REDCAP_API_TOKEN="$REDCAP_API_TOKEN_IRB_ZH_HANT" ./export-redcap-scan
+    ./transform <(./export-redcap-scan) <(./export-id3c-scan-return-results)
 }
 
 print-help() {

--- a/bin/scan-return-of-results/generate-results-csv
+++ b/bin/scan-return-of-results/generate-results-csv
@@ -26,12 +26,11 @@ main() {
     ./transform <(export-redcap-data) <(./export-id3c-scan-return-results)
 }
 
-# Exports data using all given REDCap project API tokens, output as one csv.
-# The first export keeps the header, all subsequent ones skip it.
+# Exports data for all REDCap projects as one NDJSON stream.
 export-redcap-data() {
     REDCAP_API_TOKEN="$REDCAP_API_TOKEN_IRB_EN" ./export-redcap-scan
-    REDCAP_API_TOKEN="$REDCAP_API_TOKEN_IRB_ES" ./export-redcap-scan | tail -n +2
-    REDCAP_API_TOKEN="$REDCAP_API_TOKEN_IRB_ZH_HANT" ./export-redcap-scan | tail -n +2
+    REDCAP_API_TOKEN="$REDCAP_API_TOKEN_IRB_ES" ./export-redcap-scan
+    REDCAP_API_TOKEN="$REDCAP_API_TOKEN_IRB_ZH_HANT" ./export-redcap-scan
 }
 
 print-help() {

--- a/bin/scan-return-of-results/transform
+++ b/bin/scan-return-of-results/transform
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Join the REDCap csv data with an ID3C csv.
+Join the REDCap NDJSON data with an ID3C CSV.
 Parses the joined data to make it suitable for UW Lab Med's return of results
 portal.
 """
@@ -15,7 +15,8 @@ def parse_redcap(redcap_file) -> pd.DataFrame:
     prepared in the specifications of UW Lab Med's return of results portal.
     """
     redcap_data = (
-        pd.read_csv(redcap_file, dtype = 'string')
+        pd.read_json(redcap_file, lines = True, dtype = False, convert_dates = False)
+        .astype("string")
         .pipe(trim_whitespace)
         .replace("", pd.NA)
         .rename(columns={'birthday': 'birth_date'}))
@@ -82,9 +83,9 @@ def edit_status_code(scan_data: pd.DataFrame) -> pd.DataFrame:
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
-        description="Join a REDCAP export csv file with a SCAN return of results ID3C export csv file."
+        description="Join a REDCAP export NDJSON file with a SCAN return of results ID3C export CSV file."
     )
-    parser.add_argument("redcap_data", help="CSV export of SCAN records from REDCap")
+    parser.add_argument("redcap_data", help="NDJSON export of SCAN records from REDCap")
     parser.add_argument("id3c_data", help="CSV export of SCAN return of results from ID3C")
     parser.add_argument("output", help="A destination for the output csv", nargs="?",
         default=sys.stdout)

--- a/bin/scan-return-of-results/transform
+++ b/bin/scan-return-of-results/transform
@@ -148,7 +148,10 @@ if __name__ == '__main__':
     id3c_data = pd.read_csv(args.id3c_data, dtype = 'string')
     id3c_data['qrcode'] = normalize_barcode(id3c_data['qrcode'])
 
-    # We can't return results without participant info so keep all from redcap_data
+    # Only keep records we can match from both REDCap and ID3C.  An incorrect
+    # barcode in REDCap or the lack of a record in ID3C may cause records to
+    # drop out in the join, but this is preferable to attaching results to an
+    # incorrect barcode or not having a known status for a barcode.
     joined_data = redcap_data.merge(id3c_data, how='inner', on='qrcode')
     joined_data = edit_status_code(joined_data)
 

--- a/bin/scan-return-of-results/transform
+++ b/bin/scan-return-of-results/transform
@@ -14,10 +14,13 @@ def parse_redcap(redcap_file) -> pd.DataFrame:
     Reads in data from a given *redcap_file*. Returns a pandas.DataFrame
     prepared in the specifications of UW Lab Med's return of results portal.
     """
-    redcap_data = pd.read_csv(redcap_file, dtype = 'string')
-    redcap_data = redcap_data.rename(columns={'birthday': 'birth_date'})
+    redcap_data = (
+        pd.read_csv(redcap_file, dtype = 'string')
+        .pipe(trim_whitespace)
+        .replace("", pd.NA)
+        .rename(columns={'birthday': 'birth_date'}))
 
-    participant_name = lambda row: f"{row['participant_first_name'].strip()} {row['participant_last_name'].strip()}"
+    participant_name = lambda row: f"{row['participant_first_name']} {row['participant_last_name']}"
     redcap_data['pat_name'] = redcap_data.apply(participant_name, axis='columns')
 
     # This invariant protects our filename assumptions.
@@ -45,6 +48,15 @@ def parse_redcap(redcap_file) -> pd.DataFrame:
 
 def normalize_barcode(barcode):
     return barcode.str.upper().str.strip()
+
+
+def trim_whitespace(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Trim leading and trailing whitespace from strings in *df*.
+    """
+    str_columns = df.select_dtypes("string").columns
+    df[str_columns] = df[str_columns].apply(lambda column: column.str.strip())
+    return df
 
 
 def edit_status_code(scan_data: pd.DataFrame) -> pd.DataFrame:

--- a/bin/scan-return-of-results/transform
+++ b/bin/scan-return-of-results/transform
@@ -27,9 +27,60 @@ def parse_redcap(redcap_file) -> pd.DataFrame:
     # This invariant protects our filename assumptions.
     assert all(redcap_data['birth_date'].str.match(r"^\d{4}-\d{2}-\d{2}$").dropna())
 
-    # Only use the barcode scanned during unboxing, which is input only after
-    # confirming identity.
-    barcodes = normalize_barcode(redcap_data['return_utm_barcode'])
+    # Normalize all barcode fields upfront.
+    barcode_fields = {
+        "return_utm_barcode",
+        "utm_tube_barcode_2",
+        "reenter_barcode",
+        "reenter_barcode_2"}
+
+    for barcode_field in barcode_fields:
+        if barcode_field in redcap_data:
+            redcap_data[barcode_field] = normalize_barcode(redcap_data[barcode_field])
+        else:
+            redcap_data[barcode_field] = pd.Series(dtype = "string")
+
+    # For our at-home mailed kits, return_utm_barcode is the most reliable.  It
+    # is scanned during unboxing of returned kits after confirming the
+    # participant's identity.  At-home kits also have a utm_tube_barcode_2
+    # which is manually entered by the participant; it is double-entered into
+    # reenter_barcode.  We *do not* use participant-entered barcodes for mailed
+    # kits, so those get pre-emptively blanked.
+    #
+    # For our kiosk/in-person collections, utm_tube_barcode_2 is scanned by
+    # staff.  If scanning doesn't work, then a manually-entered barcode is in
+    # reenter_barcode; it is double-entered into reenter_barcode_2.
+    collection_via = redcap_data["project_collection_via"]
+
+    redcap_data.loc[collection_via != "kiosk", "utm_tube_barcode_2"] = pd.NA
+    redcap_data.loc[collection_via != "kiosk", "reenter_barcode"]    = pd.NA
+
+    return_utm_barcode = redcap_data["return_utm_barcode"]
+    utm_tube_barcode_2 = redcap_data["utm_tube_barcode_2"]
+    reenter_barcode    = redcap_data["reenter_barcode"]
+    reenter_barcode_2  = redcap_data["reenter_barcode_2"]
+
+    # Censor manually-entered barcodes which don't match.
+    mismatched = (
+          (reenter_barcode.notna() | reenter_barcode_2.notna())
+        & reenter_barcode.ne(reenter_barcode_2, fill_value = ""))
+
+    if not mismatched[mismatched].empty:
+        print(f"Censoring {mismatched[mismatched].size:,} manually-entered barcodes which do not match each other", file = sys.stderr)
+
+    redcap_data.loc[mismatched, "reenter_barcode"]   = pd.NA
+    redcap_data.loc[mismatched, "reenter_barcode_2"] = pd.NA
+
+    assert all(reenter_barcode.eq(reenter_barcode_2, fill_value = "").dropna())
+
+    # Use best barcode available depending on the project.
+    #
+    # Note that combine_first() only applies for NA values (e.g. not empty
+    # strings); the NA-handling above is important.
+    mail_barcodes  = return_utm_barcode
+    kiosk_barcodes = utm_tube_barcode_2.combine_first(reenter_barcode)
+
+    barcodes = kiosk_barcodes.where(collection_via == "kiosk", mail_barcodes)
 
     # There should be absolutely no duplicates, but REDCap can't enforce this,
     # so warn and drop any that we find.

--- a/bin/scan-return-of-results/transform
+++ b/bin/scan-return-of-results/transform
@@ -152,4 +152,4 @@ if __name__ == '__main__':
     joined_data = redcap_data.merge(id3c_data, how='inner', on='qrcode')
     joined_data = edit_status_code(joined_data)
 
-    joined_data[['qrcode', 'pat_name', 'birth_date', 'collect_ts', 'result_ts', 'status_code']].to_csv(args.output, index=False)
+    joined_data[['qrcode', 'pat_name', 'birth_date', 'collect_ts', 'result_ts', 'status_code', 'swab_type', 'staff_observed']].to_csv(args.output, index=False)


### PR DESCRIPTION
See commit messages for details.

I believe the barcode handling is correct and appropriately cautious, but I'm not super happy with the Pandas bits. I wonder if there's a clearer approach. Happy to hear suggestions!

This is ready for review, although there's one remaining commit/todo item before this merges:

- [x] Add `swab_type` and `staff_collected` fields (or whatever their final names are) to the output of `transform`. Depends on https://github.com/seattleflu/id3c-customizations/pull/119.