### PR TITLE
Export Seattle neighborhoods as svgs

### DIFF
--- a/bin/seattle-neighborhood-svgs/create-svgs
+++ b/bin/seattle-neighborhood-svgs/create-svgs
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""
+Create SVG elements from exported ID3C paths.
+"""
+import os
+import argparse
+import pandas as pd
+from pathlib import Path
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description= __doc__,
+        formatter_class=argparse.RawTextHelpFormatter
+    )
+
+    parser.add_argument("input",
+        metavar="<input.csv>",
+        help="A CSV export of the shipping.seattle_neighborhood_districts_v1 "
+            "view.")
+    parser.add_argument("--output-dir",
+        metavar="<output-directory>",
+        default=os.getcwd(),
+        required=False,
+        help="An optional directory under which to save the created SVG files. "
+            "By default, saves to the current working directory.")
+
+    args = parser.parse_args()
+
+    neighborhoods = pd.read_csv(args.input)
+
+    neighborhoods['svg'] = neighborhoods.apply(
+        lambda row: f'<svg viewBox="0 0 100 100"><path d="{row.svg_path}" /></svg>', axis='columns'
+    )
+
+    for _, row in neighborhoods.iterrows():
+        with open(f"{Path(args.output_dir) / row.identifier}.svg", 'w') as f:
+            f.write(row.svg)

--- a/bin/seattle-neighborhood-svgs/export-id3c-svg-paths
+++ b/bin/seattle-neighborhood-svgs/export-id3c-svg-paths
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+psql --quiet --no-align --tuples-only --set ON_ERROR_STOP= <<<"
+    \copy (select * from shipping.seattle_neighborhood_districts_v1) to pstdout with (format csv, header);
+"


### PR DESCRIPTION
Add two scripts to export the Seattle neighborhood shapefiles in ID3C as
flat SVG files to be used by Formative in the public-facing dashboard.

=======================================

These SVGs look ok in Inkscape but are appear rather small on import regardless of the width and height I assign in the viewBox. This should be fine considering that SVGs are by definition scalable. Any thoughts here?