### PR TITLE
Suppress no id warning for experimental barcodes

### DIFF
--- a/id3c-production/logging.yaml
+++ b/id3c-production/logging.yaml
@@ -34,20 +34,20 @@ loggers:
       - INFO
 
 filters:
-  unknown sample warnings for controls from id3c etl presence-absence:
+  unknown sample warnings for controls and experimental samples from id3c etl presence-absence:
     (): id3c.logging.filters.suppress_records_matching
     name: id3c.cli.command.etl.presence_absence
     levelname: WARNING
     msg:
-      pattern: Skipping results for sample without a known identifier «(.+?_(Plasmid|PBS|Xeno|Water|HAP1)|NWGC_CONTROL|Water_Control|PTC_.+?)»
+      pattern: Skipping results for sample without a known identifier «(.+?_(Plasmid|PBS|Xeno|Water|HAP1|exp)|NWGC_CONTROL|Water_Control|PTC_.+?)»
 
-  unknown sample warnings for controls from id3c.db.find_identifier:
+  unknown sample warnings for controls and experimental samples from id3c.db.find_identifier:
     (): id3c.logging.filters.suppress_records_matching
     name: id3c.db
     funcName: find_identifier
     levelname: WARNING
     msg:
-      pattern: No identifier found for barcode «(.+?_(Plasmid|PBS|Xeno|Water|HAP1)|NWGC_CONTROL|Water_Control|PTC_.+?)»
+      pattern: No identifier found for barcode «(.+?_(Plasmid|PBS|Xeno|Water|HAP1|exp)|NWGC_CONTROL|Water_Control|PTC_.+?)»
 
 handlers:
   console:
@@ -57,8 +57,8 @@ handlers:
       - INFO
     formatter: console
     filters:
-      - unknown sample warnings for controls from id3c etl presence-absence
-      - unknown sample warnings for controls from id3c.db.find_identifier
+      - unknown sample warnings for controls and experimental samples from id3c etl presence-absence
+      - unknown sample warnings for controls and experimental samples from id3c.db.find_identifier
 
   # This handler emits all log levels; filtering is more usefully done by
   # syslog itself.

--- a/id3c-testing/logging.yaml
+++ b/id3c-testing/logging.yaml
@@ -34,20 +34,20 @@ loggers:
       - INFO
 
 filters:
-  unknown sample warnings for controls from id3c etl presence-absence:
+  unknown sample warnings for controls and experimental samples from id3c etl presence-absence:
     (): id3c.logging.filters.suppress_records_matching
     name: id3c.cli.command.etl.presence_absence
     levelname: WARNING
     msg:
-      pattern: Skipping results for sample without a known identifier «(.+?_(Plasmid|PBS|Xeno|Water|HAP1)|NWGC_CONTROL|Water_Control|PTC_.+?)»
+      pattern: Skipping results for sample without a known identifier «(.+?_(Plasmid|PBS|Xeno|Water|HAP1|exp)|NWGC_CONTROL|Water_Control|PTC_.+?)»
 
-  unknown sample warnings for controls from id3c.db.find_identifier:
+  unknown sample warnings for controls and experimental samples from id3c.db.find_identifier:
     (): id3c.logging.filters.suppress_records_matching
     name: id3c.db
     funcName: find_identifier
     levelname: WARNING
     msg:
-      pattern: No identifier found for barcode «(.+?_(Plasmid|PBS|Xeno|Water|HAP1)|NWGC_CONTROL|Water_Control|PTC_.+?)»
+      pattern: No identifier found for barcode «(.+?_(Plasmid|PBS|Xeno|Water|HAP1|exp)|NWGC_CONTROL|Water_Control|PTC_.+?)»
 
 handlers:
   console:
@@ -57,8 +57,8 @@ handlers:
       - INFO
     formatter: console
     filters:
-      - unknown sample warnings for controls from id3c etl presence-absence
-      - unknown sample warnings for controls from id3c.db.find_identifier
+      - unknown sample warnings for controls and experimental samples from id3c etl presence-absence
+      - unknown sample warnings for controls and experimental samples from id3c.db.find_identifier
 
   # This handler emits all log levels; filtering is more usefully done by
   # syslog itself.


### PR DESCRIPTION
Filter out warnings for sample barcodes with suffix "*_exp", which is used by the lab for
experimental barcodes. These warnings are ignorable because these barcodes are not meant
to be ingested by the presence/absence and manifest ETL jobs.

https://trello.com/c/lolX0N3y/691-suppress-warning-for-barcodes-with-exp-suffix