### PR TITLE
Suppress manifest etl warning for experimental barcodes

### DIFF
--- a/id3c-production/logging.yaml
+++ b/id3c-production/logging.yaml
@@ -49,6 +49,13 @@ filters:
     msg:
       pattern: No identifier found for barcode «(.+?_(Plasmid|PBS|Xeno|Water|HAP1|exp)|NWGC_CONTROL|Water_Control|PTC_.+?)»
 
+  unknown sample warnings for experimental samples from id3c etl manifest:
+    (): id3c.logging.filters.suppress_records_matching
+    name: id3c.cli.command.etl.manifest
+    levelname: WARNING
+    msg:
+      pattern: Skipping sample with unknown sample barcode «(.+?_exp)»
+
 handlers:
   console:
     class: logging.StreamHandler
@@ -59,6 +66,7 @@ handlers:
     filters:
       - unknown sample warnings for controls and experimental samples from id3c etl presence-absence
       - unknown sample warnings for controls and experimental samples from id3c.db.find_identifier
+      - unknown sample warnings for experimental samples from id3c etl manifest
 
   # This handler emits all log levels; filtering is more usefully done by
   # syslog itself.

--- a/id3c-testing/logging.yaml
+++ b/id3c-testing/logging.yaml
@@ -49,6 +49,13 @@ filters:
     msg:
       pattern: No identifier found for barcode «(.+?_(Plasmid|PBS|Xeno|Water|HAP1|exp)|NWGC_CONTROL|Water_Control|PTC_.+?)»
 
+  unknown sample warnings for experimental samples from id3c etl manifest:
+    (): id3c.logging.filters.suppress_records_matching
+    name: id3c.cli.command.etl.manifest
+    levelname: WARNING
+    msg:
+      pattern: Skipping sample with unknown sample barcode «(.+?_exp)»
+
 handlers:
   console:
     class: logging.StreamHandler
@@ -59,6 +66,7 @@ handlers:
     filters:
       - unknown sample warnings for controls and experimental samples from id3c etl presence-absence
       - unknown sample warnings for controls and experimental samples from id3c.db.find_identifier
+      - unknown sample warnings for experimental samples from id3c etl manifest
 
   # This handler emits all log levels; filtering is more usefully done by
   # syslog itself.


### PR DESCRIPTION
Add an additional log pattern to filter out the manifest etl warnings for sample barcodes with suffix "*_exp", which is used by the lab for experimental barcodes

(Followup to https://github.com/seattleflu/backoffice/pull/67 to also ignore the manifest etl warnings for these barcodes)

https://trello.com/c/lolX0N3y/691-suppress-warning-for-barcodes-with-exp-suffix