### PR TITLE
scan-return-of-results: Avoid Pandas bug when replacing empty strings with NA

### DIFF
--- a/bin/scan-return-of-results/transform
+++ b/bin/scan-return-of-results/transform
@@ -18,7 +18,8 @@ def parse_redcap(redcap_file) -> pd.DataFrame:
         pd.read_json(redcap_file, lines = True, dtype = False, convert_dates = False)
         .astype("string")
         .pipe(trim_whitespace)
-        .replace("", pd.NA)
+        .replace({"": pd.NA})
+        .astype("string")
         .rename(columns={'birthday': 'birth_date'}))
 
     participant_name = lambda row: f"{row['participant_first_name']} {row['participant_last_name']}"


### PR DESCRIPTION
A recent upgrade of Pandas caused the replacing of empty strings
(created by whitespace trimming) with NA to stop working.  This
manifested as both a FutureWarning from NumPy:

    .../lib/python3.6/site-packages/pandas/core/missing.py:49:
    FutureWarning: elementwise comparison failed; returning scalar instead,
    but in the future will perform elementwise comparison

(a symptom of the Pandas bug) and also our own warning about large
numbers of records containing the "duplicate" empty string barcode:

    Dropped 1,483 REDCap records with duplicated barcodes: ['']

This, it turns out, is a known bug in replace()¹ when called in its
two-arg form.  However, the bug didn't seem to affect the string dtype
until recently.

Strangely, the one-dict-arg form of replace() is not affected by the bug
and successfully replaces the empty strings with NA.  It is, however,
affected by another bug² which converts the dtype from string → object
after replacement.  Converting back to the string dtype works around
this.  Note that it is important to keep the existing initial conversion
to the string dtype as our trim_whitespace() only works on string
columns.

While I believe this bug had the potential to suppress returning of some
results, it does not appear to have impacted any, just created a bunch
of noisy logs and alerts.

¹ https://github.com/pandas-dev/pandas/issues/32075
² https://github.com/pandas-dev/pandas/issues/35268