### PR TITLE
export-id3c-scan-retun-results: exclude results with null swab_type

### DIFF
--- a/bin/scan-return-of-results/export-id3c-scan-return-results
+++ b/bin/scan-return-of-results/export-id3c-scan-return-results
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 psql --quiet --no-align --tuples-only --set ON_ERROR_STOP= <<<"
-    \copy (select * from shipping.scan_return_results_v1) to pstdout with (format csv, header);
+    \copy (select * from shipping.scan_return_results_v1 where swab_type is not null or status_code = 'pending') to pstdout with (format csv, header);
 "


### PR DESCRIPTION
Exclude results that are not pending and have a null swab_type.
This is done to prevent the return of results from being blocked by the
lack of swab type for never tested samples. The timing of a sample
getting marked as `never-tested` in REDCap and added to the
incident report is out of our control. This may lead to a block of
results since we cannot generate a PDF report without a known swab type.

A separate query is set up on Metabase to check hourly for null swab
types so that we know when we need to manually intervene.