### PR TITLE
scan-return-of-results/transform: set null swab_type to "pending" status

### DIFF
--- a/bin/scan-return-of-results/transform
+++ b/bin/scan-return-of-results/transform
@@ -118,6 +118,8 @@ def edit_status_code(scan_data: pd.DataFrame) -> pd.DataFrame:
     `inconclusive` but the participant has not yet been contacted
     (`contacted` != 'yes').
 
+    Sets the *scan_data* status to `pending` if a record has a null swab type.
+
     Returns the modified *scan_data*.
     """
     # Assume a null value for `contacted` means not contacted
@@ -129,6 +131,8 @@ def edit_status_code(scan_data: pd.DataFrame) -> pd.DataFrame:
     participant_contacted = scan_data['contacted'] == 'yes'
 
     scan_data.loc[(is_positive | is_inconclusive) & ~(participant_contacted), 'status_code'] = 'pending'
+
+    scan_data.loc[scan_data['swab_type'].isnull(), 'status_code'] = 'pending'
 
     return scan_data
 


### PR DESCRIPTION
This is done to prevent the return of results from being blocked by the
lack of swab type for never tested samples. The timing of a sample
getting marked as `never-tested` in REDCap and added to the
incident report is out of our control. This may lead to a block of
results since we cannot generate a PDF report without a known swab type.

A separate query is set up on Metabase to check hourly for null swab
types so that we know when we need to manually intervene.