### PR TITLE
Add aliquot sheet 8 to uw-retrospectives manifest

### DIFF
--- a/etc/uw-retrospectives-manifest.yaml
+++ b/etc/uw-retrospectives-manifest.yaml
@@ -68,3 +68,13 @@ extra_columns:
   mrn: mrn
   accession_no: accession
   sample_origin: sample_origin
+---
+workbook: s3://fh-pi-bedford-t/seattleflu/bbi/2019_2020_sfs_aliquoting_8.xlsx
+sheet: aliquoting
+sample_column: sample_id
+extra_columns:
+  barcode: sample_id
+  collection_date: collection_date
+  mrn: mrn
+  accession_no: accession
+  sample_origin: sample_origin


### PR DESCRIPTION
Add configuration for the latest specimen manifests aliquoting sheet,
number 8, to the UW retrospectives manifest file.

-----------------
Depends on https://github.com/seattleflu/specimen-manifests/pull/16