### PR TITLE
crontabs: Run specimen-manifests/update-unattended under pipenv

### DIFF
--- a/crontabs/id3c-production
+++ b/crontabs/id3c-production
@@ -40,7 +40,7 @@ XDG_RUNTIME_DIR=/home/ubuntu/run
 # Manifest is uploaded to AWS at arbitrary times now, so check for new records every 10m.
 # This is often the blocker for the presence/absence ETl, so run more frequently than
 # the presence/absence ETL to avoid extended delay of results.
-*/10 * * * * ubuntu chronic fatigue envdir $ENVD/hutch/ /opt/specimen-manifests/update-unattended --push-and-upload
+*/10 * * * * ubuntu chronic fatigue envdir $ENVD/hutch/ pipenv run /opt/specimen-manifests/update-unattended --push-and-upload
 
 # Upload new UW retrospectives to REDCap once a day at midnight
 0 0 * * * ubuntu pipenv run chronic envdir $ENVD/hutch/ envdir $ENVD/redcap-uw-retrospectives/ import-uw-retrospectives-to-redcap --import


### PR DESCRIPTION
Explicitly run it in our id3c-production environment instead of relying
on specimen-manifests to know the layout and location of backoffice.git.

Requires 087cba2 in specimen-manifests from the no-pipenv branch and PR
17 <https://github.com/seattleflu/specimen-manifests/pull/17>.