### PR TITLE
return-of-results: Bump Docker tag for PDFs

### DIFF
--- a/bin/return-of-results/generate-pdfs
+++ b/bin/return-of-results/generate-pdfs
@@ -50,7 +50,7 @@ main() {
             --env=LOG_LEVEL \
             --user "$(id -u):$(id -g)" \
             "${mounts[@]}" \
-            seattleflu/lab-result-reports:build-23 \
+            seattleflu/lab-result-reports:build-24 \
                 fill-template \
                     --template "scan-irb/report-$lang.tex" \
                     --params "$params" \


### PR DESCRIPTION
Bump the Docker tag used to generate PDFs so we're making PDFs with the
latest template that uses SFS branding instead of SCAN.

This should be merged in sync with the rebranded SecureLink site going live.