### PR TITLE
uw-ehs-report: Populate symptomatic_when_tested

### DIFF
--- a/bin/uw-ehs-report/export-redcap-uw-reopening
+++ b/bin/uw-ehs-report/export-redcap-uw-reopening
@@ -43,7 +43,11 @@ FIELDS = [
 
     # barcodes
     "collect_barcode_kiosk",
-    "return_utm_barcode"
+    "return_utm_barcode",
+
+    # non PII fields that we don't ingest into ID3C
+    "illness_kiosk",
+    "illness_swabsend"
 ]
 
 

--- a/bin/uw-ehs-report/transform
+++ b/bin/uw-ehs-report/transform
@@ -91,9 +91,16 @@ def parse_redcap(redcap_file) -> pd.DataFrame:
     enrollments.dropna(subset = {'netid'}, inplace = True)
 
     encounters = redcap_data.query('redcap_event_name == "encounter_arm_1"')[[ \
-        'record_id', \
-        'barcode' \
+        'record_id',
+        'barcode',
+        'illness_kiosk',
+        'illness_swabsend'
         ]]
+
+    # Set symptomatic_when_tested on encounters.
+    # Use '1' and '0' values to be consistent with the other boolean values we send to REDCap.
+    encounters.loc[(encounters['illness_kiosk'] == 'yes') | (encounters['illness_swabsend'] == 'yes'), 'symptomatic_when_tested'] = '1'
+    encounters.loc[(encounters['illness_kiosk'] == 'no') | (encounters['illness_swabsend'] == 'no'), 'symptomatic_when_tested'] = '0'
 
     joined_data = enrollments.merge(encounters, how='inner', on='record_id')
 
@@ -148,9 +155,6 @@ if __name__ == '__main__':
 
     id3c_data = pd.read_csv(args.id3c_data, dtype = 'string')
     id3c_data['barcode'] = normalize_barcode(id3c_data['barcode'])
-
-    # Placeholder field until the data pull gets implemented in ID3C.
-    id3c_data['symptomatic_when_tested'] = pd.NA
 
     # When you export a record set from Postgres as CSV, boolean columns
     # get values of 't' and 'f'. The EH&S transfer REDCap project expects

--- a/bin/uw-ehs-report/transform
+++ b/bin/uw-ehs-report/transform
@@ -195,7 +195,7 @@ if __name__ == '__main__':
         'on_campus_frequency_description', 'able_to_work_or_study_from_home_code',
         'able_to_work_or_study_from_home_description','is_uw_greek_member', 'uw_greek_house',
         'greek_other', 'housing_type', 'number_house_members', 'lives_with_uw_students_or_employees',
-        'uw_dorm_name', 'lives_in_uw_apartment',
+        'uw_dorm_name', 'uw_dorm_room_number', 'lives_in_uw_apartment',
         'uw_apartment_name', 'study_tier', 'symptomatic_when_tested'
 
         ]].to_csv(args.output, index=False)


### PR DESCRIPTION
Replacing a placeholder NA value with the actual computed value for symptomatic_when_tested.
The ETL does not ingest the questionnaire items from the two instruments where these fields are, so I'm pulling directly from REDCap.