### PR TITLE
web: Add link to Lead Dawgs app

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -71,6 +71,10 @@
         <h2 class="ts-dark">/switchboard</h2>
         <p>Quickly look up SCAN barcodes in REDCap.</p>
       </a>
+      <a class="bg-purple" href="/husky-musher/lead-dawgs">
+        <h2 class="ts-dark">Lead Dawgs</h2>
+        <p>Streamline Husky Coronavirus Testing kiosks.</p>
+      </a>
     </nav>
   </body>
 </html>


### PR DESCRIPTION
Link to the new /husky-musher/lead-dawgs app for streamlining kiosk
testing for UW Reopening.

Depends on https://github.com/seattleflu/husky-musher/pull/4