### PR TITLE
Add SFS Childcare to ROR

### DIFF
--- a/bin/return-of-results/export-redcap-sfs-longitudinal
+++ b/bin/return-of-results/export-redcap-sfs-longitudinal
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
-# usage: export-redcap-uw-reopening
+# usage: export-redcap-sfs-longitudinal
 #
-# Exports participant information from the UW-Reopening REDCap project
-# (Husky Coronavirus Testing) as NDJSON.
+# Exports participant information from SFS longitudinal REDCap projects as NDJSON.
 # REDCap projects are processed according to the YAML configuration in $CONFIG,
 # which defaults to etc/sfs-longitudinal-redcap-projects.yaml.
 #

--- a/bin/return-of-results/export-redcap-uw-reopening
+++ b/bin/return-of-results/export-redcap-uw-reopening
@@ -3,73 +3,105 @@
 #
 # Exports participant information from the UW-Reopening REDCap project
 # (Husky Coronavirus Testing) as NDJSON.
+# REDCap projects are processed according to the YAML configuration in $CONFIG,
+# which defaults to etc/sfs-longitudinal-redcap-projects.yaml.
+#
+# The $CONFIG file is expected to have at least one YAML document in it with
+# the following format:
+#
+#   ---
+#   project_id: 23854
+#   source: uw_reopening
+#   redcap_api_url_env_name: REDCAP_API_URL
+#   redcap_api_token_env_name: REDCAP_API_TOKEN_UW_REOPENING
+#   enrollment_event_names:
+#     - enrollment_arm_1
+#   enrollment_fields:
+#     - core_participant_first_name
+#     - core_participant_last_name
+#     - core_birthdate
+#   encounter_event_names:
+#     - encounter_arm_1
+#   encounter_fields:
+#     - collect_barcode_kiosk
+#     - return_utm_barcode
 #
 import sys
 import json
+import yaml
+from pathlib import Path
 from id3c.cli.redcap import Project
 from os import environ
-from typing import Dict
+from typing import Dict, List, Any
+
+config_file  = environ.get("CONFIG")
+
+if not config_file:
+    base_dir = Path(__file__).parent.parent.parent.resolve()
+    config_file = base_dir / "etc/sfs-longitudinal-redcap-projects.yaml"
 
 
-REDCAP_API_URL = environ["REDCAP_API_URL"]
-REDCAP_API_TOKEN = environ["REDCAP_API_TOKEN_UW_REOPENING"]
-REDCAP_PROJECT_ID = 23854
+class SFSProject(Project):
+    source: str
+    enrollment_event_names: List[str]
+    enrollment_fields: List[str]
+    encounter_event_names: List[str]
+    encounter_fields: List[str]
 
-ENROLLMENT_EVENT = "enrollment_arm_1"
-ENROLLMENT_FIELDS = [
-    "core_participant_first_name",
-    "core_participant_last_name",
-    "core_birthdate",
-]
+    def __init__(self, config: Dict[str, Any]):
+        REDCAP_API_URL = environ[config['redcap_api_url_env_name']]
+        REDCAP_API_TOKEN = environ[config['redcap_api_token_env_name']]
 
-ENCOUNTER_EVENT = "encounter_arm_1"
-ENCOUNTER_FIELDS = [
-    "collect_barcode_kiosk",
-    "return_utm_barcode",
-]
-
+        super().__init__(REDCAP_API_URL, REDCAP_API_TOKEN, config['project_id'])
+        self.source = config['source']
+        self.enrollment_event_names = config['enrollment_event_names']
+        self.enrollment_fields = config['enrollment_fields']
+        self.encounter_event_names = config['encounter_event_names']
+        self.encounter_fields = config['encounter_fields']
 
 
 def main():
-    project = Project(REDCAP_API_URL, REDCAP_API_TOKEN, REDCAP_PROJECT_ID)
+    with config_file.open() as f:
+        configs = list(yaml.safe_load_all(f))
 
-    enrollment_records = fetch_enrollment_records(project)
+    for config in configs:
+        project = SFSProject(config)
 
-    # Update encounter data with enrollment data based on `record_id`
-    # Skip the record if it does not have enrollment data
-    for record in fetch_encounter_records(project):
-        record_id = record["record_id"]
-        enrollment_data = enrollment_records.get(record_id)
-        if not enrollment_data:
-            continue
+        enrollment_records = fetch_enrollment_records(project)
 
-        record.update(enrollment_data)
-        print(json.dumps(record, indent = None, separators = ",:"), flush = True)
+        # Update encounter data with enrollment data based on record.id
+        # Skip the record if it does not have enrollment data
+        for record in fetch_encounter_records(project):
+            enrollment_data = enrollment_records.get(record.id)
+            if not enrollment_data:
+                continue
+
+            record.update(enrollment_data)
+            record['source'] = project.source
+            print(json.dumps(record, indent = None, separators = ",:"), flush = True)
 
 
 def fetch_enrollment_records(project) -> Dict[str, dict]:
     """
-    Fetch all enrollment records from *project* from the ENROLLMENT_EVENT.
+    Fetch all enrollment records with *project.enrollment_event_names*.
     Returns a dictionary of record ids and their corresponding fields for
-    records that have all ENROLLMENT_FIELDS completed.
+    records that have all *project.enrollment_fields* completed.
 
-    Only expects one enrollment event per record_id, will drop any record_id
+    Only expects one enrollment event per record id, will drop any record id
     that has multiple records.
     """
     redcap_records: Dict[str,dict] = {}
     duplicate_record_ids = set()
 
-    fields = ["record_id"] + ENROLLMENT_FIELDS
-    for record in project.records(events = [ENROLLMENT_EVENT], fields = fields, raw = True):
-        if not all(len(record[field]) for field in ENROLLMENT_FIELDS):
+    fields = [project.record_id_field] + project.enrollment_fields
+    for record in project.records(events = project.enrollment_event_names, fields = fields, raw = True):
+        if not all(len(record[field]) for field in project.enrollment_fields):
             continue
 
-        record_id = record.pop("record_id")
+        if record.id in redcap_records:
+            duplicate_record_ids.add(record.id)
 
-        if record_id in redcap_records:
-            duplicate_record_ids.add(record_id)
-
-        redcap_records[record_id] = { field: record[field] for field in ENROLLMENT_FIELDS }
+        redcap_records[record.id] = { field: record[field] for field in project.enrollment_fields }
 
     if duplicate_record_ids:
         for record_id in duplicate_record_ids:
@@ -83,13 +115,13 @@ def fetch_enrollment_records(project) -> Dict[str, dict]:
 
 def fetch_encounter_records(project):
     """
-    Fetch all encounter records that are from the ENCOUNTER_EVENT.
-    Only include the encounter record if at least one of the ENCOUNTER_FIELDS
-    is completed.
+    Fetch all encounter records with *project.encounter_event_names*.
+    Only include the encounter record if at least one of the
+    *project.encounter_fileds* is completed.
     """
-    fields = ["record_id"] + ENCOUNTER_FIELDS
-    for record in project.records(events = [ENCOUNTER_EVENT], fields = fields, raw = True):
-        if not any(len(record[field]) for field in ENCOUNTER_FIELDS):
+    fields = [project.record_id_field] + project.encounter_fields
+    for record in project.records(events = project.encounter_event_names, fields = fields, raw = True):
+        if not any(len(record[field]) for field in project.encounter_fields):
             continue
 
         yield record

--- a/bin/return-of-results/generate-results-csv
+++ b/bin/return-of-results/generate-results-csv
@@ -23,7 +23,7 @@ main() {
     # Change to the ./bin/return-of-results directory in the backoffice checkout
     cd "$(dirname "$0")"
 
-    ./transform <(./export-redcap-scan) <(./export-redcap-uw-reopening) <(./export-id3c-return-results)
+    ./transform <(./export-redcap-scan) <(./export-redcap-sfs-longitudinal) <(./export-id3c-return-results)
 }
 
 print-help() {

--- a/bin/return-of-results/transform
+++ b/bin/return-of-results/transform
@@ -209,6 +209,9 @@ if __name__ == '__main__':
 
     redcap_data = scan_redcap_data.append(sfs_redcap_data)
 
+    # Check for duplicate barcodes across ALL projects.
+    redcap_data["qrcode"] = drop_duplicate_barcodes(redcap_data["qrcode"])
+
     id3c_data = pd.read_csv(args.id3c_data, dtype = 'string')
     id3c_data['qrcode'] = normalize_barcode(id3c_data['qrcode'])
 

--- a/bin/return-of-results/transform
+++ b/bin/return-of-results/transform
@@ -93,9 +93,9 @@ def parse_scan_redcap(redcap_file) -> pd.DataFrame:
     return redcap_data[['qrcode', 'pat_name', 'birth_date', 'contacted', 'source']]
 
 
-def parse_uw_reopening_redcap(redcap_file) -> pd.DataFrame:
+def parse_sfs_longitudinal_redcap(redcap_file) -> pd.DataFrame:
     """
-    Reads in data from a given UW Reopening *redcap_file*. Returns a
+    Reads in data from a given SFS longitudinal *redcap_file*. Returns a
     pandas.DataFrame prepared in the specifications of UW Lab Med's return
     of results portal.
     """
@@ -197,7 +197,7 @@ if __name__ == '__main__':
         description="Join a REDCAP export NDJSON file with a SCAN return of results ID3C export CSV file."
     )
     parser.add_argument("scan_redcap_data", help="NDJSON export of SCAN records from REDCap")
-    parser.add_argument("uw_reopening_redcap_data", help="NDJSON export of UW Reopening records from REDCap")
+    parser.add_argument("sfs_longitudinal_redcap_data", help="NDJSON export of SFS longitudinal records from REDCap")
     parser.add_argument("id3c_data", help="CSV export of SCAN return of results from ID3C")
     parser.add_argument("output", help="A destination for the output csv", nargs="?",
         default=sys.stdout)
@@ -205,9 +205,9 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     scan_redcap_data = parse_scan_redcap(args.scan_redcap_data)
-    uw_reopening_redcap_data = parse_uw_reopening_redcap(args.uw_reopening_redcap_data)
+    sfs_redcap_data = parse_sfs_longitudinal_redcap(args.sfs_longitudinal_redcap_data)
 
-    redcap_data = scan_redcap_data.append(uw_reopening_redcap_data)
+    redcap_data = scan_redcap_data.append(sfs_redcap_data)
 
     id3c_data = pd.read_csv(args.id3c_data, dtype = 'string')
     id3c_data['qrcode'] = normalize_barcode(id3c_data['qrcode'])

--- a/bin/return-of-results/transform
+++ b/bin/return-of-results/transform
@@ -130,8 +130,7 @@ def parse_sfs_longitudinal_redcap(redcap_file) -> pd.DataFrame:
     barcodes = drop_duplicate_barcodes(barcodes)
 
     redcap_data['qrcode'] = barcodes
-    redcap_data['contacted'] = pd.NA
-    redcap_data['source'] = 'uw_reopening'
+    redcap_data.loc[redcap_data['source'] == 'uw_reopening', 'contacted'] = pd.NA
 
     return redcap_data[['qrcode', 'pat_name', 'birth_date', 'contacted', 'source']]
 
@@ -170,7 +169,7 @@ def edit_status_code(results: pd.DataFrame) -> pd.DataFrame:
     """
     Sets the *results* status to `pending` if a test result is `positive` or
     `inconclusive` but the participant has not yet been contacted
-    (`contacted` != 'yes') for SCAN samples only (`source` == 'scan')
+    (`contacted` != 'yes') for SCAN and SFS Childcare samples.
 
     Sets the *results* status to `pending` if a record has a null swab type.
 
@@ -183,9 +182,9 @@ def edit_status_code(results: pd.DataFrame) -> pd.DataFrame:
     is_inconclusive = results['status_code'] == 'inconclusive'
 
     participant_contacted = results['contacted'] == 'yes'
-    is_scan_data = results['source'] == 'scan'
+    require_contacted = results['source'].isin(['scan', 'childcare'])
 
-    results.loc[(is_positive | is_inconclusive) & ~(participant_contacted) & is_scan_data, 'status_code'] = 'pending'
+    results.loc[(is_positive | is_inconclusive) & ~(participant_contacted) & require_contacted, 'status_code'] = 'pending'
 
     results.loc[results['swab_type'].isnull(), 'status_code'] = 'pending'
 

--- a/etc/sfs-longitudinal-redcap-projects.yaml
+++ b/etc/sfs-longitudinal-redcap-projects.yaml
@@ -14,3 +14,37 @@ encounter_event_names:
 encounter_fields:
   - collect_barcode_kiosk
   - return_utm_barcode
+---
+project_id: 23740
+source: childcare
+redcap_api_url_env_name: REDCAP_API_URL
+redcap_api_token_env_name: REDCAP_API_TOKEN_CHILDCARE
+enrollment_event_names:
+  - enrollment_arm_1
+  - enrollment_arm_2
+enrollment_fields:
+  - core_participant_first_name
+  - core_participant_last_name
+  - core_birthdate
+encounter_event_names:
+  - week1_mon_test_arm_1
+  - week1_thur_test_arm_1
+  - week2_mon_test_arm_1
+  - week2_thur_test_arm_1
+  - week3_mon_test_arm_1
+  - week3_thur_test_arm_1
+  - week4_mon_test_arm_1
+  - week4_thur_test_arm_1
+  - week5_mon_test_arm_1
+  - week5_thur_test_arm_1
+  - week6_mon_test_arm_1
+  - week6_thur_test_arm_1
+  - week7_mon_test_arm_1
+  - week7_thur_test_arm_1
+  - week8_mon_test_arm_1
+  - week8_thur_test_arm_1
+  - enrollment_arm_2
+  - week_2_arm_2
+encounter_fields:
+  - return_utm_barcode
+  - contacted

--- a/etc/sfs-longitudinal-redcap-projects.yaml
+++ b/etc/sfs-longitudinal-redcap-projects.yaml
@@ -1,0 +1,16 @@
+---
+project_id: 23854
+source: uw_reopening
+redcap_api_url_env_name: REDCAP_API_URL
+redcap_api_token_env_name: REDCAP_API_TOKEN_UW_REOPENING
+enrollment_event_names:
+  - enrollment_arm_1
+enrollment_fields:
+  - core_participant_first_name
+  - core_participant_last_name
+  - core_birthdate
+encounter_event_names:
+  - encounter_arm_1
+encounter_fields:
+  - collect_barcode_kiosk
+  - return_utm_barcode


### PR DESCRIPTION
* Generalize the UW-reopening REDCap export script to export any SFS longitudinal REDCap project that is defined in the `etc/sfs-longitudinal-redcap-projects.yaml` config file.

* Update the ROR transform script to required contacted field for SFS Childcare studies

* Check for duplicate barcodes across __all__ studies instead of just within each study arm.