### PR TITLE
fatigue: Modify to suppress multiple, repeated warnings

### DIFF
--- a/bin/fatigue
+++ b/bin/fatigue
@@ -105,7 +105,7 @@ main() {
     # Run the given command, with output sent to the new state file.
     "$@" &>"$new_state" && exited=0 || exited=$?
 
-    if [[ $exited -ne 0 ]]; then
+    if [[ $exited -ne 0 || -s "$new_state" ]]; then
         if [[ ! -e "$old_state" || "$(hash-state "$new_state")" != "$(hash-state "$old_state")" ]]; then
             # A new error! Save it for later and exit with error.
             cat "$new_state"

--- a/bin/fatigue
+++ b/bin/fatigue
@@ -105,7 +105,7 @@ main() {
     # Run the given command, with output sent to the new state file.
     "$@" &>"$new_state" && exited=0 || exited=$?
 
-    if [[ $exited -ne 0 || -s "$new_state" ]]; then
+    if [[ $exited -ne 0 || (-s "$new_state" && $quiet -eq 1) ]]; then
         if [[ ! -e "$old_state" || "$(hash-state "$new_state")" != "$(hash-state "$old_state")" ]]; then
             # A new error! Save it for later and exit with error.
             cat "$new_state"

--- a/crontabs/return-of-results
+++ b/crontabs/return-of-results
@@ -12,4 +12,4 @@ ENVD=/opt/backoffice/id3c-production/env.d
 
 
 # Generate data file and PDFs for returning SFS results via UW Lab Med's SecureLink portal
-5,35 * * * * ubuntu promjob "return of results" flock --no-fork --nonblock /var/lock/return-of-results pipenv run envdir $ENVD/redcap-scan/ envdir $ENVD/redcap-sfs envdir $ENVD/securelink/ /opt/backoffice/bin/return-of-results/generate
+5,35 * * * * ubuntu promjob "return of results" flock --no-fork --nonblock /var/lock/return-of-results fatigue --quiet pipenv run envdir $ENVD/redcap-scan/ envdir $ENVD/redcap-sfs envdir $ENVD/securelink/ /opt/backoffice/bin/return-of-results/generate

--- a/crontabs/uw-ehs-report
+++ b/crontabs/uw-ehs-report
@@ -11,4 +11,4 @@ PGSERVICE=production-etl
 ENVD=/opt/backoffice/id3c-production/env.d
 
 # Generate data file of results for UW Reopening (Husky Testing) and upload to EHS for followup
-# 7,37 * * * * ubuntu promjob "uw-ehs-report" pipenv run envdir $ENVD/redcap-sfs/ envdir $ENVD/redcap-uw-reopening-ehs-transfer /opt/backoffice/bin/uw-ehs-report/generate
+# 7,37 * * * * ubuntu promjob "uw-ehs-report" fatigue --quiet pipenv run envdir $ENVD/redcap-sfs/ envdir $ENVD/redcap-uw-reopening-ehs-transfer /opt/backoffice/bin/uw-ehs-report/generate


### PR DESCRIPTION
Previously, fatigue only specially handled suppressing repeated warnings
of jobs that exit with an error. Modify fatigue to also suppress jobs
with any sterr output. Sterr output is generated at the "warning" and
"error" log levels, so this will reduce the warnings alert spam we
receive via email and in the #id3c-alerts channel.