### PR TITLE
id3c-production: Remove specimen-manifest DIFF_FILE env vars

### DIFF
--- a/id3c-production/env.d/aliquot-manifest-processing/DIFF_FILE
+++ b/id3c-production/env.d/aliquot-manifest-processing/DIFF_FILE
@@ -1,1 +1,0 @@
-aliquot-diff.ndjson

--- a/id3c-production/env.d/incident-report-manifest-processing/DIFF_FILE
+++ b/id3c-production/env.d/incident-report-manifest-processing/DIFF_FILE
@@ -1,1 +1,0 @@
-incident-report-diff.ndjson


### PR DESCRIPTION
No longer needed as the manifest processing uses temp files for the
diff, see 941376a8 in specimen-manifests.git.