### PR TITLE
Update to season 3 manifest

### DIFF
--- a/id3c-production/env.d/aliquot-manifest-processing/CONFIG
+++ b/id3c-production/env.d/aliquot-manifest-processing/CONFIG
@@ -1,1 +1,1 @@
-/opt/specimen-manifests/season-2-AWS-S3.yaml
+/opt/specimen-manifests/season-3-AWS-S3.yaml

--- a/id3c-production/env.d/aliquot-manifest-processing/MANIFEST
+++ b/id3c-production/env.d/aliquot-manifest-processing/MANIFEST
@@ -1,1 +1,1 @@
-season-2-manifest.ndjson
+season-3-manifest.ndjson


### PR DESCRIPTION
Update the `update-unattended` specimen manifests cron job environment
variables to pull from the new, season 3 manifest sheet.

Note that the lab does not anticipate updating the season 2 manifest save any barcode corrections. If these arise, the plan is to handle them manually.

Depends on https://github.com/seattleflu/specimen-manifests/pull/22