### PR TITLE
Export basic cronjob metrics to Prometheus

### DIFF
--- a/bin/promjob
+++ b/bin/promjob
@@ -1,0 +1,78 @@
+#!/bin/bash
+# usage: promjob <name> <command> [<args> …]
+#
+# Runs a cronjob <command> and afterwards exports basic metrics (start time,
+# end time, duration, exit status) to Prometheus' node_exporter's textfile
+# collector.  A <name> for the cronjob must be given as the first argument; it
+# will be attached to the metrics as a "name" label.
+#
+# Set TEXTFILE_COLLECTOR_DIR to override the default directory for metric
+# collection (/var/lib/prometheus/node-exporter).
+#
+set -euo pipefail
+
+: ${TEXTFILE_COLLECTOR_DIR:=/var/lib/prometheus/node-exporter}
+
+if [[ ! -w "$TEXTFILE_COLLECTOR_DIR" ]]; then
+    echo "error: $TEXTFILE_COLLECTOR_DIR does not exist or is not writable" >&2
+    exit 1
+fi
+
+main() {
+    local cronjob promfile started ended exited
+
+    # Label for the cronjob
+    cronjob="$(escape-label-value "${1:?error: a cronjob name must be provided as the first argument.}")"
+    shift
+
+    # Determine a safe but stable filename for the exported metrics.
+    promfile="$TEXTFILE_COLLECTOR_DIR/$(md5 "$cronjob").prom"
+
+    # Record start time.
+    started="$(date +%s)"
+
+    # Run the passed command, with the effect of "set -e" temporarily disabled,
+    # saving the exit status for later.
+    "$@" && exited=0 || exited=$?
+
+    # Record end time and write metrics atomically.
+    ended="$(date +%s)"
+
+    cat >"$promfile.$$" <<.
+# HELP cronjob_start_time_seconds Start time of the cronjob since Unix epoch in seconds.
+# TYPE cronjob_start_time_seconds gauge
+cronjob_start_time_seconds{name="$cronjob"} $started
+
+# HELP cronjob_end_time_seconds End time of the cronjob since Unix epoch in seconds.
+# TYPE cronjob_end_time_seconds gauge
+cronjob_end_time_seconds{name="$cronjob"} $ended
+
+# HELP cronjob_duration_seconds Duration of the cronjob in seconds.
+# TYPE cronjob_duration_seconds gauge
+cronjob_duration_seconds{name="$cronjob"} $(($ended - $started))
+
+# HELP cronjob_exit_status Exit status of the cronjob.
+# TYPE cronjob_exit_status gauge
+cronjob_exit_status{name="$cronjob"} $exited
+.
+    mv "$promfile.$$" "$promfile"
+
+    # Exit same status as the passed command.
+    exit $exited
+}
+
+escape-label-value() {
+    # Escape " and \ and replace newlines with \n
+    perl -pe '
+        chomp;
+        s/(?=["\\])/\\/g;
+        s/\n/\\n/g;
+    ' <<<"$1"
+}
+
+md5() {
+    # Print just the digest, skipping the filename.
+    md5sum <<<"$1" | awk '{print $1}'
+}
+
+main "$@"

--- a/crontabs/id3c-production
+++ b/crontabs/id3c-production
@@ -17,54 +17,54 @@ XDG_RUNTIME_DIR=/home/ubuntu/run
 
 # Longitudinal childcare records are manually uploaded right now, so just check
 # once an hour at five past.
-5 * * * * ubuntu pipenv run id3c etl longitudinal --commit
+5 * * * * ubuntu promjob "id3c etl longitudinal" pipenv run id3c etl longitudinal --commit
 
 # Genomes are uploaded irregularly.  Once an hour should be good for now.
-10 * * * * ubuntu pipenv run id3c etl consensus-genome --commit
+10 * * * * ubuntu promjob "id3c etl consensus-genome" pipenv run id3c etl consensus-genome --commit
 
 # Audere sends us data at quarter past.  It rarely takes more than a minute,
 # but ensure we process everything they might send by waiting until 20 after.
-20 * * * * ubuntu pipenv run id3c etl enrollments --commit
+20 * * * * ubuntu promjob "id3c etl enrollments" pipenv run id3c etl enrollments --commit
 
 # Kit records are created/updated from enrollment records from Audere. To ensure
 # that this doesn't run at the same time as the enrollments etl, run at 25 after.
-25 * * * * ubuntu pipenv run id3c etl kit enrollments --commit
+25 * * * * ubuntu promjob "id3c etl kit enrollments" pipenv run id3c etl kit enrollments --commit
 
 # Test results are pushed at arbitrary times now, so check for new ones every 15m.
-*/15 * * * * ubuntu fatigue --quiet pipenv run id3c etl presence-absence --commit
+*/15 * * * * ubuntu promjob "id3c etl presence-absence" fatigue --quiet pipenv run id3c etl presence-absence --commit
 
 # 5 minutes after presence/absence results are uploaded,
 # check if any contain reportable conditions.
-5-50/15 * * * * ubuntu envdir $ENVD/slack pipenv run id3c reportable-conditions notify --commit
+5-50/15 * * * * ubuntu promjob "id3c reportable-conditions notify" envdir $ENVD/slack pipenv run id3c reportable-conditions notify --commit
 
 # The aliquot manifest is uploaded to AWS at arbitrary times now, so check for new records every 10m.
 # This is often the blocker for the presence/absence ETl, so run more frequently than
 # the presence/absence ETL to avoid extended delay of results.
-*/10 * * * * ubuntu chronic fatigue envdir $ENVD/aliquot-manifest-processing/ envdir $ENVD/hutch/ pipenv run /opt/specimen-manifests/update-unattended --push-and-upload
+*/10 * * * * ubuntu promjob "manifest update: aliquots" chronic fatigue envdir $ENVD/aliquot-manifest-processing/ envdir $ENVD/hutch/ pipenv run /opt/specimen-manifests/update-unattended --push-and-upload
 
 # Process the incident report manifest from Google Sheets at :25 and :55 past the hour.
 # Don't run at 10 minutes on the hour so we don't interfere with the aliquot job.
-25,55 * * * * ubuntu chronic fatigue envdir $ENVD/incident-report-manifest-processing/ envdir $ENVD/google/ pipenv run /opt/specimen-manifests/update-unattended --push-and-upload
+25,55 * * * * ubuntu promjob "manifest update: incidents" chronic fatigue envdir $ENVD/incident-report-manifest-processing/ envdir $ENVD/google/ pipenv run /opt/specimen-manifests/update-unattended --push-and-upload
 
 # Upload new UW retrospectives to REDCap once a day at midnight
-0 0 * * * ubuntu pipenv run chronic envdir $ENVD/hutch/ envdir $ENVD/redcap-uw-retrospectives/ import-uw-retrospectives-to-redcap --import
+0 0 * * * ubuntu promjob "redcap-uw-retrospectives: import-to-redcap" pipenv run chronic envdir $ENVD/hutch/ envdir $ENVD/redcap-uw-retrospectives/ import-uw-retrospectives-to-redcap --import
 
 # Create and upload REDCap DETs for UW retrospectives once a day at 4 A.M.
-0 4 * * * ubuntu pipenv run chronic envdir $ENVD/redcap-uw-retrospectives/ generate-and-upload-uw-retro-redcap-dets
+0 4 * * * ubuntu promjob "redcap-uw-retrospectives: generate-and-upload-dets" pipenv run chronic envdir $ENVD/redcap-uw-retrospectives/ generate-and-upload-uw-retro-redcap-dets
 
 # Run the manifest ETL 5 minutes after new manifest records are uploaded
-5-55/10 * * * * ubuntu fatigue --quiet pipenv run id3c etl manifest --commit
+5-55/10 * * * * ubuntu promjob "id3c etl manifest" fatigue --quiet pipenv run id3c etl manifest --commit
 
 # Kit records are created/updated from manifest records. To ensure that this
 # doesn't run at the same time as manifest etl, run ten 'till.
-50 * * * * ubuntu pipenv run id3c etl kit manifest --commit
+50 * * * * ubuntu promjob "id3c etl kit manifest" pipenv run id3c etl kit manifest --commit
 
 # Parse and upload the latest SCH retrospective data from S3 to ID3C
-51 * * * * ubuntu chronic envdir $ENVD/hutch envdir $ENVD/deidentification upload-sch-retrospective-data-pulls --upload
+51 * * * * ubuntu promjob "SCH retrospectives" chronic envdir $ENVD/hutch envdir $ENVD/deidentification upload-sch-retrospective-data-pulls --upload
 
 # Clinical encounter records are manually uploaded right now, so just check
 # once an hour at five 'till.
-55 * * * * ubuntu pipenv run id3c etl clinical --commit
+55 * * * * ubuntu promjob "id3c etl clinical" pipenv run id3c etl clinical --commit
 
 # XXX TODO: Explicitly configure the location the geocoding cache when that is
 # supported by our code.  Currently it ends up as cache.pickle in the working
@@ -78,11 +78,11 @@ XDG_RUNTIME_DIR=/home/ubuntu/run
 # ingested once every 8 hours. Keeping these in case any data corrections are made.
 # The uw-retro REDCap project is still active, but it only needs to be run
 # once a day after the DET generation at 4 A.M.
-0 0-16/8 * * * ubuntu flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-uw-retrospectives pipenv run id3c etl redcap-det uw-retrospectives --commit
-0 1-17/8 * * * ubuntu flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-swab-n-send pipenv run id3c etl redcap-det swab-n-send --commit
-0 2-18/8 * * * ubuntu flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-kiosk pipenv run id3c etl redcap-det kiosk --commit
-0 3-19/8 * * * ubuntu flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-swab-and-home-flu pipenv run id3c etl redcap-det swab-and-home-flu --commit
-0 4-20/8 * * * ubuntu flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-asymptomatic-swab-n-send pipenv run id3c etl redcap-det asymptomatic-swab-n-send --commit
+0 0-16/8 * * * ubuntu promjob "id3c etl redcap-det uw-retrospectives"        flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-uw-retrospectives pipenv run id3c etl redcap-det uw-retrospectives --commit
+0 1-17/8 * * * ubuntu promjob "id3c etl redcap-det swab-n-send"              flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-swab-n-send pipenv run id3c etl redcap-det swab-n-send --commit
+0 2-18/8 * * * ubuntu promjob "id3c etl redcap-det kiosk"                    flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-kiosk pipenv run id3c etl redcap-det kiosk --commit
+0 3-19/8 * * * ubuntu promjob "id3c etl redcap-det swab-and-home-flu"        flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-swab-and-home-flu pipenv run id3c etl redcap-det swab-and-home-flu --commit
+0 4-20/8 * * * ubuntu promjob "id3c etl redcap-det asymptomatic-swab-n-send" flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-asymptomatic-swab-n-send pipenv run id3c etl redcap-det asymptomatic-swab-n-send --commit
 
 # Ingest each SCAN Surveillance REDCap project every hour, interleaving the
 # projects so each gets ingested once every 8 hours.
@@ -90,37 +90,37 @@ XDG_RUNTIME_DIR=/home/ubuntu/run
 # SCAN Research Study. Keeping these in case any data corrects are made.
 # Deleted jobs for Surveillance REDCap projects that did not have any records
 # as of 08 June, 2020.
-0 5-21/8 * * * ubuntu flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-scan-en pipenv run id3c etl redcap-det scan-en --commit
-0 6-22/8 * * * ubuntu flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-scan-es pipenv run id3c etl redcap-det scan-es --commit
-0 7-23/8 * * * ubuntu flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-scan-zh-Hant pipenv run id3c etl redcap-det scan-zh-Hant --commit
+0 5-21/8 * * * ubuntu promjob "id3c etl redcap-det scan-en"      flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-scan-en pipenv run id3c etl redcap-det scan-en --commit
+0 6-22/8 * * * ubuntu promjob "id3c etl redcap-det scan-es"      flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-scan-es pipenv run id3c etl redcap-det scan-es --commit
+0 7-23/8 * * * ubuntu promjob "id3c etl redcap-det scan-zh-Hant" flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-scan-zh-Hant pipenv run id3c etl redcap-det scan-zh-Hant --commit
 
 # Ingest each SCAN Research REDCap project every 30 min (with the
 # first starting 5 minutes after the SFS/SCAN Surveillance ingests above.)
-5,35 * * * * ubuntu flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-scan-irb-en pipenv run id3c etl redcap-det scan-irb-en --commit
-7,37 * * * * ubuntu flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-scan-irb-es pipenv run id3c etl redcap-det scan-irb-es --commit
-9,39 * * * * ubuntu flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-scan-irb-zh-Hant pipenv run id3c etl redcap-det scan-irb-zh-Hant --commit
-11,41 * * * * ubuntu flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-scan-irb-kiosk-en pipenv run id3c etl redcap-det scan-irb-kiosk-en --commit
-13,43 * * * * ubuntu flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-scan-irb-ru pipenv run id3c etl redcap-det scan-irb-ru --commit
-15,45 * * * * ubuntu flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-scan-irb-husky-en pipenv run id3c etl redcap-det scan-irb-husky-en --commit
-17,47 * * * * ubuntu flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-scan-irb-vi pipenv run id3c etl redcap-det scan-irb-vi --commit
+5,35  * * * * ubuntu promjob "id3c etl redcap-det scan-irb-en"       flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-scan-irb-en pipenv run id3c etl redcap-det scan-irb-en --commit
+7,37  * * * * ubuntu promjob "id3c etl redcap-det scan-irb-es"       flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-scan-irb-es pipenv run id3c etl redcap-det scan-irb-es --commit
+9,39  * * * * ubuntu promjob "id3c etl redcap-det scan-irb-zh-Hant"  flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-scan-irb-zh-Hant pipenv run id3c etl redcap-det scan-irb-zh-Hant --commit
+11,41 * * * * ubuntu promjob "id3c etl redcap-det scan-irb-kiosk-en" flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-scan-irb-kiosk-en pipenv run id3c etl redcap-det scan-irb-kiosk-en --commit
+13,43 * * * * ubuntu promjob "id3c etl redcap-det scan-irb-ru"       flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-scan-irb-ru pipenv run id3c etl redcap-det scan-irb-ru --commit
+15,45 * * * * ubuntu promjob "id3c etl redcap-det scan-irb-husky-en" flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-scan-irb-husky-en pipenv run id3c etl redcap-det scan-irb-husky-en --commit
+17,47 * * * * ubuntu promjob "id3c etl redcap-det scan-irb-vi"       flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-scan-irb-vi pipenv run id3c etl redcap-det scan-irb-vi --commit
 
 # Ingest UW REopening REDCap project every 30 min (after SCAN projects above).
 # We should probably increase the frequency in the near future (for testing
 # quota purposes) when the SmaryStreets cache handling is updated.
-19,49 * * * * ubuntu flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-uw-reopening pipenv run id3c etl redcap-det uw-reopening --redcap-api-batch-size 750 --commit
+19,49 * * * * ubuntu promjob "id3c etl redcap-det uw-reopening" flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-uw-reopening pipenv run id3c etl redcap-det uw-reopening --redcap-api-batch-size 750 --commit
 
 # Ingest Childcare REDCap project every 30 min (after UW Reopening project above).
 # Use redcap-api-batch-size = 1000 because this REDCap project is longitudinal.
-21,51 * * * * ubuntu flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-childcare pipenv run id3c etl redcap-det childcare --redcap-api-batch-size 1000 --commit
+21,51 * * * * ubuntu promjob "id3c etl redcap-det childcare" flock -F /home/ubuntu/cache.pickle envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap-childcare pipenv run id3c etl redcap-det childcare --redcap-api-batch-size 1000 --commit
 
 # Ingest FHIR documents every 5 minutes.
-*/5  * * * * ubuntu fatigue --quiet pipenv run id3c etl fhir --commit
+*/5  * * * * ubuntu promjob "id3c etl fhir" fatigue --quiet pipenv run id3c etl fhir --commit
 
 # Run the idle database session disconnector routine every minute
-* * * * * ubuntu fatigue --quiet terminate-idle-sessions
+* * * * * ubuntu promjob "terminate-idle-sessions" fatigue --quiet terminate-idle-sessions
 # Run the old metabase session disconnector routine every minute
-* * * * * ubuntu fatigue --quiet terminate-old-metabase-sessions
+* * * * * ubuntu promjob "terminate-old-metabase-sessions" fatigue --quiet terminate-old-metabase-sessions
 # Run the refresh materialized view routine every 5 minutes include latest
 # ingested FHIR documents in the view
-*/5 * * * * ubuntu fatigue --quiet pipenv run id3c refresh-materialized-view shipping fhir_questionnaire_responses_v1 --commit
-*/5 * * * * ubuntu fatigue --quiet pipenv run id3c refresh-materialized-view shipping scan_encounters_v1 --commit
+*/5 * * * * ubuntu promjob "refresh-materialized-view: shipping.fhir_questionnaire_responses_v1" fatigue --quiet pipenv run id3c refresh-materialized-view shipping fhir_questionnaire_responses_v1 --commit
+*/5 * * * * ubuntu promjob "refresh-materialized-view: shipping.scan_encounters_v1"              fatigue --quiet pipenv run id3c refresh-materialized-view shipping scan_encounters_v1 --commit

--- a/crontabs/return-of-results
+++ b/crontabs/return-of-results
@@ -12,4 +12,4 @@ ENVD=/opt/backoffice/id3c-production/env.d
 
 
 # Generate data file and PDFs for returning SFS results via UW Lab Med's SecureLink portal
-5,35 * * * * ubuntu flock --no-fork --nonblock /var/lock/return-of-results pipenv run envdir $ENVD/redcap-scan/ envdir $ENVD/redcap-sfs envdir $ENVD/securelink/ /opt/backoffice/bin/return-of-results/generate
+5,35 * * * * ubuntu promjob "return of results" flock --no-fork --nonblock /var/lock/return-of-results pipenv run envdir $ENVD/redcap-scan/ envdir $ENVD/redcap-sfs envdir $ENVD/securelink/ /opt/backoffice/bin/return-of-results/generate

--- a/crontabs/scan-switchboard
+++ b/crontabs/scan-switchboard
@@ -12,4 +12,4 @@ XDG_RUNTIME_DIR=/home/ubuntu/run
 
 
 # Refresh the SCAN Switchboard SQLite database every 10 minutes
-*/10 * * * * ubuntu chronic fatigue envdir $ENVD/redcap-sfs/ envdir $ENVD/redcap-scan/ pipenv run make -BC /opt/scan-switchboard
+*/10 * * * * ubuntu promjob "switchboard refresh" chronic fatigue envdir $ENVD/redcap-sfs/ envdir $ENVD/redcap-scan/ pipenv run make -BC /opt/scan-switchboard

--- a/crontabs/uw-ehs-report
+++ b/crontabs/uw-ehs-report
@@ -11,4 +11,4 @@ PGSERVICE=production-etl
 ENVD=/opt/backoffice/id3c-production/env.d
 
 # Generate data file of results for UW Reopening (Husky Testing) and upload to EHS for followup
-7,37 * * * * ubuntu pipenv run envdir $ENVD/redcap-sfs/ envdir $ENVD/redcap-uw-reopening-ehs-transfer /opt/backoffice/bin/uw-ehs-report/generate
+7,37 * * * * ubuntu promjob "uw-ehs-report" pipenv run envdir $ENVD/redcap-sfs/ envdir $ENVD/redcap-uw-reopening-ehs-transfer /opt/backoffice/bin/uw-ehs-report/generate


### PR DESCRIPTION
Adds a new exec-chaining command, "promjob", which writes metrics (start
time, end time, duration, exit status) to Prometheus' node_exporter's
textfile collector directory.  These metrics will let us monitor (and
alert, if we wish) on the status of our jobs.

Notably, promjob will still work nicely if/when we move from cronjobs to
systemd timers (as I increasingly thing we should do) or even other
scheduled task systems.  In the case of systemd, invocations can re-use
the systemd unit name via interpolation, e.g. `promjob %N …`.

Another way to think about this same information would be via an
event-log mindset, where the cron logs (e.g. in /var/log/syslog) are
piped into an event-log store (e.g. ELK stack or CloudWatch) from which
these metrics are then computed.  This has some advantages, but since we
don't have structured event logging right now, it's simpler to publish
metrics directly for now.

---

Requires https://github.com/seattleflu/infra/pull/1.