### PR TITLE
Silence alerts for Hap1 and exp samples

### DIFF
--- a/id3c-production/logging.yaml
+++ b/id3c-production/logging.yaml
@@ -39,7 +39,7 @@ filters:
     name: id3c.cli.command.etl.presence_absence
     levelname: WARNING
     msg:
-      pattern: Skipping results for sample without a known identifier «(.+?_(Plasmid|PBS|Xeno|Water|HAP1|exp)|NWGC_CONTROL|Water_Control|PTC_.+?)»
+      pattern: Skipping results for sample without a known identifier «(.+?_(Plasmid|PBS|Xeno|Water|HAP1|exp)|exp|Hap1_Gblock|NWGC_CONTROL|Water_Control|PTC_.+?)»
 
   unknown sample warnings for controls and experimental samples from id3c.db.find_identifier:
     (): id3c.logging.filters.suppress_records_matching
@@ -47,7 +47,7 @@ filters:
     funcName: find_identifier
     levelname: WARNING
     msg:
-      pattern: No identifier found for barcode «(.+?_(Plasmid|PBS|Xeno|Water|HAP1|exp)|NWGC_CONTROL|Water_Control|PTC_.+?)»
+      pattern: No identifier found for barcode «(.+?_(Plasmid|PBS|Xeno|Water|HAP1|exp)|exp|Hap1_Gblock|NWGC_CONTROL|Water_Control|PTC_.+?)»
 
   unknown sample warnings for experimental samples from id3c etl manifest:
     (): id3c.logging.filters.suppress_records_matching

--- a/id3c-testing/logging.yaml
+++ b/id3c-testing/logging.yaml
@@ -39,7 +39,7 @@ filters:
     name: id3c.cli.command.etl.presence_absence
     levelname: WARNING
     msg:
-      pattern: Skipping results for sample without a known identifier «(.+?_(Plasmid|PBS|Xeno|Water|HAP1|exp)|NWGC_CONTROL|Water_Control|PTC_.+?)»
+      pattern: Skipping results for sample without a known identifier «(.+?_(Plasmid|PBS|Xeno|Water|HAP1|exp)|exp|Hap1_Gblock|NWGC_CONTROL|Water_Control|PTC_.+?)»
 
   unknown sample warnings for controls and experimental samples from id3c.db.find_identifier:
     (): id3c.logging.filters.suppress_records_matching
@@ -47,7 +47,7 @@ filters:
     funcName: find_identifier
     levelname: WARNING
     msg:
-      pattern: No identifier found for barcode «(.+?_(Plasmid|PBS|Xeno|Water|HAP1|exp)|NWGC_CONTROL|Water_Control|PTC_.+?)»
+      pattern: No identifier found for barcode «(.+?_(Plasmid|PBS|Xeno|Water|HAP1|exp)|exp|Hap1_Gblock|NWGC_CONTROL|Water_Control|PTC_.+?)»
 
   unknown sample warnings for experimental samples from id3c etl manifest:
     (): id3c.logging.filters.suppress_records_matching


### PR DESCRIPTION
Update our logging configuration to silence yet another test sample that
isn't meant to end up in id3c.