### PR TITLE
id3c-production: drop duplicate HCT barcodes for EHS transfer

### DIFF
--- a/bin/uw-ehs-report/transform
+++ b/bin/uw-ehs-report/transform
@@ -88,7 +88,7 @@ def parse_redcap(redcap_file) -> pd.DataFrame:
     netids = enrollments['netid']
     netids = drop_duplicate_values(netids)
     enrollments['netid'] = netids
-    enrollments.dropna(subset = {'netid'}, inplace = True)
+    enrollments.dropna(subset={'netid'}, inplace=True)
 
     encounters = redcap_data.query('redcap_event_name == "encounter_arm_1"')[[ \
         'record_id',
@@ -155,6 +155,12 @@ if __name__ == '__main__':
 
     id3c_data = pd.read_csv(args.id3c_data, dtype = 'string')
     id3c_data['barcode'] = normalize_barcode(id3c_data['barcode'])
+
+    # Drop id3c records with duplicated barcodes
+    barcodes = id3c_data['barcode']
+    barcodes = drop_duplicate_values(barcodes)
+    id3c_data['barcode'] = barcodes
+    id3c_data.dropna(subset={'barcode'}, inplace=True)
 
     # When you export a record set from Postgres as CSV, boolean columns
     # get values of 't' and 'f'. The EH&S transfer REDCap project expects


### PR DESCRIPTION
Before import data into the EH&S HCT transfer project, drop duplicate
barcodes from the dataset.