### PR TITLE
id3c-production: clarify duplicate message in EHS transform

### DIFF
--- a/bin/uw-ehs-report/transform
+++ b/bin/uw-ehs-report/transform
@@ -135,7 +135,7 @@ def drop_duplicate_values(input_series: pd.Series) -> pd.Series:
 
         dups_count = len(dups)
         dups_unique = list(dups.unique())
-        print(f"Dropped {dups_count:,} REDCap records with duplicated {input_series.name}: "
+        print(f"Dropped {dups_count:,} records with duplicated {input_series.name}: "
             f"{dups_unique if input_series.name != 'netid' else '<masked>'}", file = sys.stderr)
 
     return deduplicated_series


### PR DESCRIPTION
During transfer of HCT results to EHS, now that we are
outputting the message for duplicates values in the ID3C
dataset as well as REDCap, make the message non-specific to
REDCap.