### PR TITLE
return-of-results: Exit if id3c export fails

### DIFF
--- a/bin/return-of-results/generate-results-csv
+++ b/bin/return-of-results/generate-results-csv
@@ -23,7 +23,7 @@ main() {
     # Change to the ./bin/return-of-results directory in the backoffice checkout
     cd "$(dirname "$0")"
 
-    ./transform <(./export-redcap-scan) <(./export-redcap-sfs-longitudinal) <(./export-id3c-return-results)
+    ./transform <(./export-redcap-scan) <(./export-redcap-sfs-longitudinal) <(./export-id3c-return-results || kill $$)
 }
 
 print-help() {


### PR DESCRIPTION
Exit the return-of-results (RoR) job if the CSV export from id3c fails
(e.g. because the database is unavailable). Previously, we were not
killing the RoR job on a failed `export-id3c-return-results` command due
to our use of process substitution. I.e., as @tsibley pointed out, "when
`command` fails in `<(command)`, it doesn't propagate."

Explicitly kill the current PID when our id3c export command exits with
a non-zero exit code. This halts the entire RoR job, preventing us from
unintentionally uploading an empty CSV and overrwriting the
(unversioned) data on securelink's S3 bucket with an empty file. This
happened last month, causing the RoR job to regenerate PDFs for every
single result, which at our current program's pace, would have taken
multiple days to complete.