### PR TITLE
Explicitly specify the name of token env var for UW retros REDCap DET generation

### DIFF
--- a/bin/generate-and-upload-uw-retro-redcap-dets
+++ b/bin/generate-and-upload-uw-retro-redcap-dets
@@ -28,7 +28,7 @@ main() {
 }
 
 generate-redcap-dets() {
-    id3c redcap-det generate --project-id 19915 --since-date "`date +"%F %T" -d "25 hours ago"`" --include-incomplete
+    id3c redcap-det generate --project-id 19915 --token REDCAP_API_TOKEN --since-date "`date +"%F %T" -d "25 hours ago"`" --include-incomplete
 }
 
 upload-to-id3c() {


### PR DESCRIPTION
This works as-is now but importantly ensures forward-compatibility with
upcoming changes in ID3C to use the new-style env var names.¹  Deploying
this in advance of those changes will result in no disruption.

¹ https://github.com/seattleflu/id3c/pull/197