### PR TITLE
Cron job adjustments

### DIFF
--- a/crontabs/id3c-production
+++ b/crontabs/id3c-production
@@ -120,14 +120,14 @@ GEOCODING_CACHE=/home/ubuntu/sfs-cache.pickle
 * * * * * ubuntu promjob "terminate-idle-sessions" fatigue --quiet terminate-idle-sessions
 # Run the old metabase session disconnector routine every minute
 * * * * * ubuntu promjob "terminate-old-metabase-sessions" fatigue --quiet terminate-old-metabase-sessions
-# Run the refresh materialized view routine every 5 minutes include latest
+# Run the refresh materialized view routine every 10 minutes include latest
 # ingested FHIR documents in the view
-*/5 * * * * ubuntu promjob "refresh-materialized-view: shipping.fhir_questionnaire_responses_v1" flock -F --nonblock --conflict-exit-code 0 "$FLOCK_DIR/shipping.fhir_questionnaire_responses_v1" fatigue --quiet pipenv run id3c refresh-materialized-view shipping fhir_questionnaire_responses_v1 --commit
-*/5 * * * * ubuntu promjob "refresh-materialized-view: shipping.scan_encounters_v1"              flock -F --nonblock --conflict-exit-code 0 "$FLOCK_DIR/shipping.scan_encounters_v1" fatigue --quiet pipenv run id3c refresh-materialized-view shipping scan_encounters_v1 --commit
+*/10 * * * * ubuntu promjob "refresh-materialized-view: shipping.fhir_questionnaire_responses_v1" flock -F --nonblock --conflict-exit-code 0 "$FLOCK_DIR/shipping.fhir_questionnaire_responses_v1" fatigue --quiet pipenv run id3c refresh-materialized-view shipping fhir_questionnaire_responses_v1 --commit
+*/10 * * * * ubuntu promjob "refresh-materialized-view: shipping.scan_encounters_v1"              flock -F --nonblock --conflict-exit-code 0 "$FLOCK_DIR/shipping.scan_encounters_v1" fatigue --quiet pipenv run id3c refresh-materialized-view shipping scan_encounters_v1 --commit
 
-# Run the refresh materialized view routine for UW Reopening encounters every 8 minutes to include
+# Run the refresh materialized view routine for UW Reopening encounters every 10 minutes to include
 # latest data from other jobs, including refreshing the shipping.fhir_questionnaire_responses_v1 materialized view
-*/8 * * * * ubuntu promjob "refresh-materialized-view: shipping.__uw_encounters" flock -F --nonblock --conflict-exit-code 0 "$FLOCK_DIR/shipping.__uw_encounters" fatigue --quiet pipenv run id3c refresh-materialized-view shipping __uw_encounters --commit
+*/10 * * * * ubuntu promjob "refresh-materialized-view: shipping.__uw_encounters" flock -F --nonblock --conflict-exit-code 0 "$FLOCK_DIR/shipping.__uw_encounters" fatigue --quiet pipenv run id3c refresh-materialized-view shipping __uw_encounters --commit
 
 # Make UW Reopening testing offers at :15 and :45
 # This job uses data created by redcap-det uw-reopening, etl fhir, and refresh-materialized-view shipping fhir_questionnaire_responses_v1

--- a/crontabs/id3c-production
+++ b/crontabs/id3c-production
@@ -106,7 +106,7 @@ GEOCODING_CACHE=/home/ubuntu/scan-cache.pickle
 
 # Ingest UW REopening REDCap project every 10 min
 GEOCODING_CACHE=/home/ubuntu/uw-reopening-cache.pickle
-*/10 * * * * ubuntu promjob "id3c etl redcap-det uw-reopening" flock -F $GEOCODING_CACHE envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap pipenv run id3c etl redcap-det uw-reopening --redcap-api-batch-size 250 --det-limit 1000 --commit
+*/10 * * * * ubuntu promjob "id3c etl redcap-det uw-reopening" flock -F $GEOCODING_CACHE envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap pipenv run id3c etl redcap-det uw-reopening --redcap-api-batch-size 150 --det-limit 1000 --commit
 
 # Ingest Childcare REDCap project every 30 min (after UW Reopening project above).
 # Use redcap-api-batch-size = 1000 because this REDCap project is longitudinal.

--- a/crontabs/id3c-production
+++ b/crontabs/id3c-production
@@ -14,6 +14,9 @@ ENVD=/opt/backoffice/id3c-production/env.d
 # Configure a private runtime directory for "fatigue".
 XDG_RUNTIME_DIR=/home/ubuntu/run
 
+# Directory to hold flock files
+FLOCK_DIR=/var/run/lock
+
 
 # Longitudinal childcare records are manually uploaded right now, so just check
 # once an hour at five past.
@@ -119,12 +122,12 @@ GEOCODING_CACHE=/home/ubuntu/sfs-cache.pickle
 * * * * * ubuntu promjob "terminate-old-metabase-sessions" fatigue --quiet terminate-old-metabase-sessions
 # Run the refresh materialized view routine every 5 minutes include latest
 # ingested FHIR documents in the view
-*/5 * * * * ubuntu promjob "refresh-materialized-view: shipping.fhir_questionnaire_responses_v1" fatigue --quiet pipenv run id3c refresh-materialized-view shipping fhir_questionnaire_responses_v1 --commit
-*/5 * * * * ubuntu promjob "refresh-materialized-view: shipping.scan_encounters_v1"              fatigue --quiet pipenv run id3c refresh-materialized-view shipping scan_encounters_v1 --commit
+*/5 * * * * ubuntu promjob "refresh-materialized-view: shipping.fhir_questionnaire_responses_v1" flock -F --nonblock --conflict-exit-code 0 "$FLOCK_DIR/shipping.fhir_questionnaire_responses_v1" fatigue --quiet pipenv run id3c refresh-materialized-view shipping fhir_questionnaire_responses_v1 --commit
+*/5 * * * * ubuntu promjob "refresh-materialized-view: shipping.scan_encounters_v1"              flock -F --nonblock --conflict-exit-code 0 "$FLOCK_DIR/shipping.scan_encounters_v1" fatigue --quiet pipenv run id3c refresh-materialized-view shipping scan_encounters_v1 --commit
 
 # Run the refresh materialized view routine for UW Reopening encounters every 8 minutes to include
 # latest data from other jobs, including refreshing the shipping.fhir_questionnaire_responses_v1 materialized view
-*/8 * * * * ubuntu promjob "refresh-materialized-view: shipping.__uw_encounters" fatigue --quiet pipenv run id3c refresh-materialized-view shipping __uw_encounters --commit
+*/8 * * * * ubuntu promjob "refresh-materialized-view: shipping.__uw_encounters" flock -F --nonblock --conflict-exit-code 0 "$FLOCK_DIR/shipping.__uw_encounters" fatigue --quiet pipenv run id3c refresh-materialized-view shipping __uw_encounters --commit
 
 # Make UW Reopening testing offers at :15 and :45
 # This job uses data created by redcap-det uw-reopening, etl fhir, and refresh-materialized-view shipping fhir_questionnaire_responses_v1


### PR DESCRIPTION
Please see notes in the commit messages. 
1. Use flock for refresh materialized view jobs.
2. Run the refresh materialized view jobs less frequently.
3. Reduce the UW Reopening ETL's redcap-api-batch-size.

Before deploying this, create a flock directory on the backoffice server:
/home/ubuntu/flock .