### PR TITLE
uw-ehs-report: Use NDJSON instead of CSV for the intermediate file format

### DIFF
--- a/bin/uw-ehs-report/generate
+++ b/bin/uw-ehs-report/generate
@@ -26,16 +26,7 @@ main() {
         esac
     done
 
-    datadir="$(TMPDIR="$base" mktemp -d -t uw_ehs_report-XXXXXX)"
-
-    # Always leave and delete this temporary directory regardless of exit code
-    trap "rm -rf '$datadir'" EXIT
-
-    # Generate the report NDJSON
-    "$bin"/generate-report > "$datadir/uw_ehs_report.ndjson"
-
-    # Import the NDJSON into the transfer REDCap project.
-    "$bin"/import-to-uw-ehs-transfer-redcap "$datadir/uw_ehs_report.ndjson"
+    "$bin"/generate-report | "$bin"/import-to-uw-ehs-transfer-redcap -
 }
 
 print-help() {

--- a/bin/uw-ehs-report/generate
+++ b/bin/uw-ehs-report/generate
@@ -31,11 +31,11 @@ main() {
     # Always leave and delete this temporary directory regardless of exit code
     trap "rm -rf '$datadir'" EXIT
 
-    # Generate the report CSV
-    "$bin"/generate-report-csv > "$datadir/uw_ehs_report.csv"
+    # Generate the report NDJSON
+    "$bin"/generate-report > "$datadir/uw_ehs_report.ndjson"
 
-    # Import the CSV into the transfer REDCap project.
-    "$bin"/import-to-uw-ehs-transfer-redcap "$datadir/uw_ehs_report.csv"
+    # Import the NDJSON into the transfer REDCap project.
+    "$bin"/import-to-uw-ehs-transfer-redcap "$datadir/uw_ehs_report.ndjson"
 }
 
 print-help() {

--- a/bin/uw-ehs-report/generate-report
+++ b/bin/uw-ehs-report/generate-report
@@ -1,12 +1,12 @@
 #!/bin/bash
-# usage: generate-report-csv
-#        generate-report-csv --help
+# usage: generate-report
+#        generate-report --help
 #
 # Joins REDCap Husky Coronavirus Testing data to data from the
 # shipping.uw_reopening_ehs_reporting_v1 view in ID3C.
 # Parses these data into a format appropriate to submit to UW EH&S.
 #
-# Resulting transformed csv is output to stdout.
+# Resulting transformed NDJSON is output to stdout.
 #
 set -euo pipefail
 

--- a/bin/uw-ehs-report/import-to-uw-ehs-transfer-redcap
+++ b/bin/uw-ehs-report/import-to-uw-ehs-transfer-redcap
@@ -1,13 +1,11 @@
 #!/usr/bin/env python3
 import argparse
 import os
-import json
 import math
-import numpy as np
-import pandas as pd
-import requests
 import logging
 import id3c.cli.redcap as redcap
+from id3c.json import load_ndjson
+from more_itertools import chunked
 from sys import stderr
 from typing import Any, Dict
 
@@ -32,20 +30,17 @@ if __name__ == '__main__':
         formatter_class=argparse.RawTextHelpFormatter
     )
 
-    parser.add_argument("filename",
-        metavar="<input-file.csv>",
-        help="An CSV file containing the data to import into EHS REDCap project")
+    parser.add_argument("input",
+        metavar="<input-file.ndjson>",
+        type=argparse.FileType("r"),
+        help="An NDJSON file containing the data to import into EHS REDCap project")
 
     args = parser.parse_args()
 
     project = redcap.Project("https://redcap.iths.org", 24025)
 
-    ehs_dataset = pd.read_csv(args.filename)
+    # Post data to REDCap in batches of 8,500 records to reduce strain on REDCap servers
+    redcap_post_batch_size = 8500
 
-    # Post data to REDCap in batches of 10000 records to reduce strain on REDCap servers
-    ehs_dataset_num_rows = ehs_dataset.shape[0]
-    redcap_post_batch_size = 10000
-    num_batches = math.ceil(ehs_dataset_num_rows / redcap_post_batch_size)
-
-    for batch in np.array_split(ehs_dataset, num_batches):
-        project.update_records(json.loads(batch.to_json(orient='records')), date_format = "MDY", check_count = False)
+    for batch in chunked(load_ndjson(args.input), redcap_post_batch_size):
+        project.update_records(batch, date_format = "MDY", check_count = False)

--- a/bin/uw-ehs-report/transform
+++ b/bin/uw-ehs-report/transform
@@ -7,6 +7,7 @@ EH&S Transfer REDCap project.
 import sys
 import argparse
 import pandas as pd
+from id3c.cli.io.pandas import dump_ndjson
 
 
 def parse_redcap(redcap_file) -> pd.DataFrame:
@@ -146,8 +147,8 @@ if __name__ == '__main__':
     )
     parser.add_argument("redcap_data", help="NDJSON export of SCAN records from REDCap")
     parser.add_argument("id3c_data", help="CSV export of SCAN return of results from ID3C")
-    parser.add_argument("output", help="A destination for the output csv", nargs="?",
-        default=sys.stdout)
+    parser.add_argument("output", help="A destination for the output NDJSON", nargs="?",
+        default=sys.stdout, type=argparse.FileType("w"))
 
     args = parser.parse_args()
 
@@ -184,7 +185,7 @@ if __name__ == '__main__':
     joined_data = redcap_data.merge(id3c_data, how='inner', on='barcode')
 
 
-    joined_data[[ \
+    dump_ndjson(joined_data[[ \
         'barcode', 'sample_collection_date', 'test_result', 'test_result_date',
 
         'netid', 'participant_first_name', 'participant_last_name', 'birthdate',
@@ -204,4 +205,4 @@ if __name__ == '__main__':
         'uw_dorm_name', 'uw_dorm_room_number', 'lives_in_uw_apartment',
         'uw_apartment_name', 'study_tier', 'symptomatic_when_tested'
 
-        ]].to_csv(args.output, index=False)
+        ]], file = args.output)

--- a/id3c-production/Pipfile.lock
+++ b/id3c-production/Pipfile.lock
@@ -188,7 +188,7 @@
         "id3c": {
             "editable": true,
             "git": "https://github.com/seattleflu/id3c.git",
-            "ref": "dfe257f7b7f5991d502d6c788112c2a827cd22cc"
+            "ref": "b09eafeb75dbea143414d2059ec329cf1c023801"
         },
         "idna": {
             "hashes": [


### PR DESCRIPTION
Motivated by the problems with the UW EH&S report yesterday.

See commit messages for details.

Todo:

- [x] Merge and push https://github.com/seattleflu/id3c/pull/206
- [ ] `pipenv update` in _id3c-production/_ and commit to this branch before merging