### PR TITLE
Stop silencing errors from the presence-absence ETL

### DIFF
--- a/crontabs/id3c-production
+++ b/crontabs/id3c-production
@@ -34,7 +34,7 @@ FLOCK_DIR=/var/run/lock
 25 * * * * ubuntu promjob "id3c etl kit enrollments" pipenv run id3c etl kit enrollments --commit
 
 # Test results are pushed at arbitrary times now, so check for new ones every 15m.
-*/15 * * * * ubuntu promjob "id3c etl presence-absence" fatigue --quiet pipenv run id3c etl presence-absence --commit
+*/15 * * * * ubuntu promjob "id3c etl presence-absence" pipenv run id3c etl presence-absence --commit
 
 # 5 minutes after presence/absence results are uploaded,
 # check if any contain reportable conditions.


### PR DESCRIPTION
We went the entire day without noticing that the presence-absence ETL
had been failing since last night. In this case I would rather see
Slack alert entries every 15 minutes than to go a day without seeing
a problem with our results release pipeline.