### PR TITLE
Accommodate afh

### DIFF
--- a/bin/return-of-results/export-redcap-sfs-classic
+++ b/bin/return-of-results/export-redcap-sfs-classic
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# usage: export-redcap-sfs-classic
+#
+# Exports participant information from SFS "classic" mode REDCap projects as NDJSON.
+# REDCap projects are processed according to the YAML configuration in $CONFIG,
+# which defaults to etc/sfs-classic-redcap-projects.yaml.
+#
+# The $CONFIG file is expected to have at least one YAML document in it with
+# the following format:
+#
+# ---
+# redcap:
+#   url: https://redcap.iths.org
+#   project: 27619 # Clinical COVID Testing (Congregate Settings)
+# source: adult_family_home_workplace_outbreak
+# contact_before_releasing_result: false
+# contacted_field: null
+# participant_first_name_field: core_participant_first_name
+# participant_last_name_field: core_participant_last_name
+# participant_birthdate_field: core_birthdate
+# additional_fields:
+#   - {"name":"ordering_provider", "required": true}
+# prioritized_barcode_fields:
+#   - core_collection_barcode
+#   - return_collection_barcode
+
+import sys
+import json
+import yaml
+from pathlib import Path
+from id3c.cli.redcap import Project
+from os import environ
+from typing import Dict, List, Any
+
+config_file  = environ.get("CONFIG")
+
+if not config_file:
+    base_dir = Path(__file__).resolve().parent.parent.parent
+    config_file = base_dir / "etc/sfs-classic-redcap-projects.yaml"
+
+
+class SFSProject(Project):
+    source: str
+    contact_before_releasing_result: bool
+    contacted_field: str
+    participant_first_name_field: str
+    participant_last_name_field: str
+    participant_birthdate_field: str
+    additional_fields: List[Dict[str, Any]]
+    prioritized_barcode_fields: List[str]
+
+    def __init__(self, config: Dict[str, Any]):
+        super().__init__(config['redcap']['url'], config['redcap']['project'])
+        self.source = config['source']
+        self.contact_before_releasing_result = config['contact_before_releasing_result']
+        self.contacted_field = config.get('contacted_field')
+        self.participant_first_name_field = config['participant_first_name_field']
+        self.participant_last_name_field = config['participant_last_name_field']
+        self.participant_birthdate_field = config['participant_birthdate_field']
+        self.additional_fields = config.get('additional_fields') or []
+        self.prioritized_barcode_fields = config['prioritized_barcode_fields']
+
+
+def main():
+    with open(config_file, 'r') as f:
+        configs = list(yaml.safe_load_all(f))
+
+    for config in configs:
+        project = SFSProject(config)
+
+        assert (not project.contact_before_releasing_result or (project.contact_before_releasing_result and project.contacted_field)), \
+        "If the project requires contact before releasing the result, you must specify the `contacted_field` field. Correct the project " \
+        f"with source: {project.source}."
+
+        for record in fetch_records(project):
+            record['source'] = project.source
+            record['contact_before_releasing_result'] = str(project.contact_before_releasing_result).lower()
+
+            barcode = None
+
+            for field in project.prioritized_barcode_fields:
+                if record.get(field):
+                    barcode = record[field]
+                    break
+
+            record['prioritized_barcode'] = barcode
+
+            # Use the record only if it has the necessary barcode fields populated
+            if barcode:
+
+                # Don't retain the raw barcode fields now that we have the prioritized one
+                for field in project.prioritized_barcode_fields:
+                    del record[field]
+
+                print(json.dumps(record, indent = None, separators = ",:"), flush = True)
+
+
+def fetch_records(project) -> List[Dict[str, dict]]:
+    """
+    Fetch all records from the REDCap project.
+    """
+    redcap_records = []
+
+    participant_fields = {project.participant_first_name_field,
+        project.participant_last_name_field, project.participant_birthdate_field}
+
+    fields = {project.record_id_field, *participant_fields, *project.prioritized_barcode_fields,
+        *[entry['name'] for entry in project.additional_fields]}
+
+    required_fields = {*participant_fields,
+        *[entry['name'] for entry in project.additional_fields if entry['required'] == True]
+        }
+
+    if project.contacted_field:
+        fields.add(project.contacted_field)
+        required_fields.add(project.contacted_field)
+
+    for record in project.records(fields = fields, raw = True):
+        if not all(len(record[field]) for field in required_fields):
+            continue
+
+        # Standardize the name of some keys
+        record['core_participant_first_name'] = record.pop(project.participant_first_name_field)
+        record['core_participant_last_name'] = record.pop(project.participant_last_name_field)
+        record['core_participant_birth_date'] = record.pop(project.participant_birthdate_field)
+
+        if project.contacted_field:
+            record['participant_contacted'] = record.pop(project.contacted_field)
+        else:
+            # Use "" to match a REDCap unset variable
+            record['participant_contacted'] = ""
+
+        redcap_records.append(record)
+
+    return redcap_records
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/return-of-results/generate-pdfs
+++ b/bin/return-of-results/generate-pdfs
@@ -8,7 +8,7 @@ main() {
     local output="${2:-s3://dokku-stack-phi/covid19/results-scan-study/{qrcode\}-{birth_date\}}"
     local -a mounts
     mounts=()
-    local docker_container_build_number="27"
+    local docker_container_build_number="28"
 
     debug "PDF_LANGS = $PDF_LANGS"
     debug "params = $params"

--- a/bin/return-of-results/generate-pdfs
+++ b/bin/return-of-results/generate-pdfs
@@ -8,6 +8,7 @@ main() {
     local output="${2:-s3://dokku-stack-phi/covid19/results-scan-study/{qrcode\}-{birth_date\}}"
     local -a mounts
     mounts=()
+    local docker_container_build_number="27"
 
     debug "PDF_LANGS = $PDF_LANGS"
     debug "params = $params"
@@ -52,13 +53,31 @@ main() {
             --env=LOG_LEVEL \
             --user "$(id -u):$(id -g)" \
             "${mounts[@]}" \
-            seattleflu/lab-result-reports:build-27 \
+            seattleflu/lab-result-reports:build-$docker_container_build_number \
                 fill-template \
                     --template "scan-irb/report-$lang.tex" \
                     --params "$params" \
                     --output "$output-$lang.pdf" \
                     --filter 'status_code not in ["not-received", "pending"] and pre_analytical_specimen_collection == "IRB" '
     done;
+
+    # Produce PDFs only in EN for samples collected under the
+    # `clinical` pre_analytical_specimen_collection because the
+    # PDF content was not translated
+    docker run \
+            --rm \
+            --interactive \
+            --env=AWS_ACCESS_KEY_ID \
+            --env=AWS_SECRET_ACCESS_KEY \
+            --env=LOG_LEVEL \
+            --user "$(id -u):$(id -g)" \
+            "${mounts[@]}" \
+            seattleflu/lab-result-reports:build-$docker_container_build_number \
+                fill-template \
+                    --template "clinical/report-en.tex" \
+                    --params "$params" \
+                    --output "$output-en.pdf" \
+                    --filter 'status_code not in ["not-received", "pending"] and pre_analytical_specimen_collection == "clinical" '
 }
 
 debug() {

--- a/bin/return-of-results/generate-pdfs
+++ b/bin/return-of-results/generate-pdfs
@@ -39,6 +39,8 @@ main() {
         debug
     fi
 
+    # Produce PDFs in each language for samples collected under
+    # the `IRB` pre_analytical_specimen_collection
     for lang in $PDF_LANGS; do
         debug "Generating PDFs for language code «${lang}»"
 
@@ -55,7 +57,7 @@ main() {
                     --template "scan-irb/report-$lang.tex" \
                     --params "$params" \
                     --output "$output-$lang.pdf" \
-                    --filter 'status_code not in ["not-received", "pending"]'
+                    --filter 'status_code not in ["not-received", "pending"] and pre_analytical_specimen_collection == "IRB" '
     done;
 }
 

--- a/bin/return-of-results/generate-results-csv
+++ b/bin/return-of-results/generate-results-csv
@@ -23,7 +23,7 @@ main() {
     # Change to the ./bin/return-of-results directory in the backoffice checkout
     cd "$(dirname "$0")"
 
-    ./transform <(./export-redcap-scan) <(./export-redcap-sfs-longitudinal) <(./export-id3c-return-results || kill $$)
+    ./transform <(./export-redcap-scan) <(./export-redcap-sfs-longitudinal) <(./export-redcap-sfs-classic) <(./export-id3c-return-results || kill $$)
 }
 
 print-help() {

--- a/bin/return-of-results/transform
+++ b/bin/return-of-results/transform
@@ -227,6 +227,27 @@ def edit_status_code(results: pd.DataFrame) -> pd.DataFrame:
     return results
 
 
+def check_data_quality(joined_data: pd.DataFrame) -> None:
+    """
+    Performs some data quality checks on the final `joined_data`
+    DataFrame and warns (by writing to sys.stderr) about records
+    that have quality issues.
+    """
+
+    # Check the `pre_analytical_specimen_collection` column
+    # pd.NA is included by ~ isin
+    no_pre_analytical_specimen_collection = joined_data[~joined_data['pre_analytical_specimen_collection'].isin \
+        (['IRB', 'clinical'])]
+
+    if not no_pre_analytical_specimen_collection.empty:
+        print(f"{len(no_pre_analytical_specimen_collection)} records have a bad pre_analytical_specimen_collection value.",
+            file = sys.stderr)
+        no_pre_analytical_specimen_collection.apply \
+            (lambda row: print(f"qrcode: «{row['qrcode']}», pre_analytical_specimen_collection: "
+            f"«{row['pre_analytical_specimen_collection']}»",
+                file = sys.stderr), axis='columns')
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description="Join a REDCAP export NDJSON file with a SCAN return of results ID3C export CSV file."
@@ -265,6 +286,8 @@ if __name__ == '__main__':
     # incorrect barcode or not having a known status for a barcode.
     joined_data = redcap_data.merge(id3c_data, how='inner', on='qrcode')
     joined_data = edit_status_code(joined_data)
+
+    check_data_quality(joined_data)
 
     # Caution: a side effect of adding columns here is that the pipeline will consider all results as new
     # when it diffs against the previous run's output, and attempt to regenerate all results PDFs.

--- a/bin/return-of-results/transform
+++ b/bin/return-of-results/transform
@@ -221,4 +221,9 @@ if __name__ == '__main__':
     joined_data = redcap_data.merge(id3c_data, how='inner', on='qrcode')
     joined_data = edit_status_code(joined_data)
 
-    joined_data[['qrcode', 'pat_name', 'birth_date', 'collect_ts', 'result_ts', 'status_code', 'swab_type', 'staff_observed']].to_csv(args.output, index=False)
+    # Caution: a side effect of adding columns here is that the pipeline will consider all results as new
+    # when it diffs against the previous run's output, and attempt to regenerate all results PDFs.
+    # That process is incredibly slow, so it may be prudent to manually backfill new columns into the
+    # previous_results.csv in S3
+
+    joined_data[['qrcode', 'pat_name', 'birth_date', 'collect_ts', 'result_ts', 'status_code', 'swab_type', 'staff_observed', 'pre_analytical_specimen_collection']].to_csv(args.output, index=False)

--- a/bin/return-of-results/transform
+++ b/bin/return-of-results/transform
@@ -244,7 +244,10 @@ if __name__ == '__main__':
     sfs_longitudinal_redcap_data = parse_sfs_longitudinal_redcap(args.sfs_longitudinal_redcap_data)
     sfs_classic_redcap_data = parse_sfs_classic_redcap(args.sfs_classic_redcap_data)
 
-    redcap_data = scan_redcap_data.append(sfs_longitudinal_redcap_data).append(sfs_classic_redcap_data)
+    # Combine the DataFrames by appending to the first.
+    # Use `ignore_index = True` to prevent duplicate index values.
+    redcap_data = scan_redcap_data.append(sfs_longitudinal_redcap_data, ignore_index = True) \
+        .append(sfs_classic_redcap_data, ignore_index = True)
 
     # After appending the DataFrames, columns that were not in all sets originally will
     # have empty string values in the final DataFrame. Replace those with pd.NA.

--- a/bin/return-of-results/transform
+++ b/bin/return-of-results/transform
@@ -135,6 +135,35 @@ def parse_sfs_longitudinal_redcap(redcap_file) -> pd.DataFrame:
     return redcap_data[['qrcode', 'pat_name', 'birth_date', 'contacted', 'source']]
 
 
+def parse_sfs_classic_redcap(redcap_file) -> pd.DataFrame:
+    """
+    Reads in data from a given SFS classic *redcap_file*. Returns a
+    pandas.DataFrame prepared in the specifications of UW Lab Med's return
+    of results portal.
+    """
+    redcap_data = (
+        pd.read_json(redcap_file, lines = True, dtype = False, convert_dates = False)
+        .astype("string")
+        .pipe(trim_whitespace)
+        .replace({"": pd.NA})
+        .astype("string")
+        .rename(columns={"core_participant_birth_date": "birth_date", "participant_contacted": "contacted"})
+    )
+
+    participant_name = lambda row: f"{row['core_participant_first_name']} {row['core_participant_last_name']}"
+    redcap_data['pat_name'] = redcap_data.apply(participant_name, axis='columns')
+
+    # This invariant protects our filename assumptions.
+    assert all(redcap_data['birth_date'].str.match(r"^\d{4}-\d{2}-\d{2}$").dropna())
+
+    redcap_data['prioritized_barcode'] = normalize_barcode(redcap_data['prioritized_barcode'])
+    barcodes = redcap_data['prioritized_barcode']
+    barcodes = drop_duplicate_barcodes(barcodes)
+    redcap_data['qrcode'] = barcodes
+
+    return redcap_data[['qrcode', 'pat_name', 'birth_date', 'contacted', 'source', 'contact_before_releasing_result', 'ordering_provider']]
+
+
 def normalize_barcode(barcode):
     return barcode.str.upper().str.strip()
 
@@ -169,7 +198,8 @@ def edit_status_code(results: pd.DataFrame) -> pd.DataFrame:
     """
     Sets the *results* status to `pending` if a test result is `positive` or
     `inconclusive` but the participant has not yet been contacted
-    (`contacted` != 'yes') for SCAN and SFS Childcare samples.
+    (`contacted` != 'yes') for SCAN and SFS Childcare samples or for records
+    with `contact_before_releasing_result` == 'true'
 
     Sets the *results* status to `pending` if a record has a null swab type.
 
@@ -182,7 +212,13 @@ def edit_status_code(results: pd.DataFrame) -> pd.DataFrame:
     is_inconclusive = results['status_code'] == 'inconclusive'
 
     participant_contacted = results['contacted'] == 'yes'
-    require_contacted = results['source'].isin(['scan', 'childcare'])
+
+    # To prevent a row's `require_contacted` value from getting set as pd.NA and then failing where we compare
+    # its value with the boolean values of the other series (is_positive, is_inconclusive, participant_contacted),
+    # first check that the value is not pd.NA before comparing its string value.
+    require_contacted_lambda = lambda row: (row['source'] is not pd.NA and row['source'] in ['scan', 'childcare']) \
+        or (row['contact_before_releasing_result'] is not pd.NA and row['contact_before_releasing_result'] == 'true')
+    require_contacted = results.apply(require_contacted_lambda, axis='columns')
 
     results.loc[(is_positive | is_inconclusive) & ~(participant_contacted) & require_contacted, 'status_code'] = 'pending'
 
@@ -197,6 +233,7 @@ if __name__ == '__main__':
     )
     parser.add_argument("scan_redcap_data", help="NDJSON export of SCAN records from REDCap")
     parser.add_argument("sfs_longitudinal_redcap_data", help="NDJSON export of SFS longitudinal records from REDCap")
+    parser.add_argument("sfs_classic_redcap_data", help="NDJSON export of SFS classic records from REDCap")
     parser.add_argument("id3c_data", help="CSV export of SCAN return of results from ID3C")
     parser.add_argument("output", help="A destination for the output csv", nargs="?",
         default=sys.stdout)
@@ -204,9 +241,14 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     scan_redcap_data = parse_scan_redcap(args.scan_redcap_data)
-    sfs_redcap_data = parse_sfs_longitudinal_redcap(args.sfs_longitudinal_redcap_data)
+    sfs_longitudinal_redcap_data = parse_sfs_longitudinal_redcap(args.sfs_longitudinal_redcap_data)
+    sfs_classic_redcap_data = parse_sfs_classic_redcap(args.sfs_classic_redcap_data)
 
-    redcap_data = scan_redcap_data.append(sfs_redcap_data)
+    redcap_data = scan_redcap_data.append(sfs_longitudinal_redcap_data).append(sfs_classic_redcap_data)
+
+    # After appending the DataFrames, columns that were not in all sets originally will
+    # have empty string values in the final DataFrame. Replace those with pd.NA.
+    redcap_data.replace("", pd.NA, inplace = True)
 
     # Check for duplicate barcodes across ALL projects.
     redcap_data["qrcode"] = drop_duplicate_barcodes(redcap_data["qrcode"])
@@ -226,4 +268,4 @@ if __name__ == '__main__':
     # That process is incredibly slow, so it may be prudent to manually backfill new columns into the
     # previous_results.csv in S3
 
-    joined_data[['qrcode', 'pat_name', 'birth_date', 'collect_ts', 'result_ts', 'status_code', 'swab_type', 'staff_observed', 'pre_analytical_specimen_collection']].to_csv(args.output, index=False)
+    joined_data[['qrcode', 'pat_name', 'birth_date', 'collect_ts', 'result_ts', 'status_code', 'swab_type', 'staff_observed', 'pre_analytical_specimen_collection', 'ordering_provider']].to_csv(args.output, index=False)

--- a/crontabs/return-of-results
+++ b/crontabs/return-of-results
@@ -15,4 +15,4 @@ XDG_RUNTIME_DIR=/home/ubuntu/run
 
 
 # Generate data file and PDFs for returning SFS results via UW Lab Med's SecureLink portal
-5,35 * * * * ubuntu promjob "return of results" flock --no-fork --nonblock /var/lock/return-of-results fatigue --quiet pipenv run envdir $ENVD/redcap envdir $ENVD/securelink/ /opt/backoffice/bin/return-of-results/generate
+#5,35 * * * * ubuntu promjob "return of results" flock --no-fork --nonblock /var/lock/return-of-results fatigue --quiet pipenv run envdir $ENVD/redcap envdir $ENVD/securelink/ /opt/backoffice/bin/return-of-results/generate

--- a/etc/sfs-classic-redcap-projects.yaml
+++ b/etc/sfs-classic-redcap-projects.yaml
@@ -1,0 +1,15 @@
+---
+redcap:
+  url: https://redcap.iths.org
+  project: 27619 # Clinical COVID Testing (Congregate Settings)
+source: adult_family_home_workplace_outbreak
+contact_before_releasing_result: false
+contacted_field: null
+participant_first_name_field: core_participant_first_name
+participant_last_name_field: core_participant_last_name
+participant_birthdate_field: core_birthdate
+additional_fields:
+  - {"name":"ordering_provider", "required": true}
+prioritized_barcode_fields:
+  - core_collection_barcode
+  - return_collection_barcode


### PR DESCRIPTION
For the AFH/Workplace project we needed a new code path to handle "classic" REDCap projects that don't follow all the rules of SCAN (doesn't require contacting the participant before releasing a positive or inconclusive result). I used the idea done with the longitudinal path to create a config-driven classic path.

When generating PDFs, we now generate a PDF in all languages for "IRB" results and use a different template for English "clinical" results.

This depends on the corresponding template changes in https://github.com/seattleflu/lab-result-reports/pull/28/files 