### PR TITLE
Remove bad assumption and combine append commands

### DIFF
--- a/bin/return-of-results/transform
+++ b/bin/return-of-results/transform
@@ -267,12 +267,7 @@ if __name__ == '__main__':
 
     # Combine the DataFrames by appending to the first.
     # Use `ignore_index = True` to prevent duplicate index values.
-    redcap_data = scan_redcap_data.append(sfs_longitudinal_redcap_data, ignore_index = True) \
-        .append(sfs_classic_redcap_data, ignore_index = True)
-
-    # After appending the DataFrames, columns that were not in all sets originally will
-    # have empty string values in the final DataFrame. Replace those with pd.NA.
-    redcap_data.replace("", pd.NA, inplace = True)
+    redcap_data = scan_redcap_data.append([sfs_longitudinal_redcap_data, sfs_classic_redcap_data], ignore_index = True)
 
     # Check for duplicate barcodes across ALL projects.
     redcap_data["qrcode"] = drop_duplicate_barcodes(redcap_data["qrcode"])


### PR DESCRIPTION
My original statement about appending DataFrames that have different
columns was incorrect. The values in the disconcordant columns will be
`NA` for a string column (and `NAN` for other types). There's no need
to replace data after the append. In fact, the `replace` line was
causing this warning:
`FutureWarning: elementwise comparison failed; returning scalar instead,
but in the future will perform elementwise comparison`

Also, the .append() method can take a list of DataFrames to append. It's
more efficient to append the two in the same command.