### PR TITLE
wa-doh-linelists: Fix HCT zipcode

### DIFF
--- a/bin/wa-doh-linelists/transform
+++ b/bin/wa-doh-linelists/transform
@@ -54,7 +54,7 @@ def relabel_values(redcap_report: pd.DataFrame, config: Dict[str, Any]) -> pd.Da
     Re-assigns raw values a meaningful label in a given *redcap_report* using
     logic in id3c-customizations and the provided *config*.
     """
-    if 'home_zipcode_2' in redcap_report:
+    if config.get('relabel_zipcodes'):
         redcap_report['home_zipcode_2'] = redcap_report['home_zipcode_2'] \
             .apply(zipcode_map)
 

--- a/etc/wa-doh-linelists.yaml
+++ b/etc/wa-doh-linelists.yaml
@@ -151,6 +151,7 @@ column_rename_map: {
 static_columns: {
   "study_arm": "SCAN",
 }
+relabel_zipcodes: True
 
 ---
 name: SCAN IRB Spanish
@@ -170,6 +171,7 @@ static_columns: {
   "study_arm": "SCAN",
   "primary_language": "Spanish",
 }
+relabel_zipcodes: True
 
 ---
 name: SCAN IRB Vietnamese
@@ -182,6 +184,7 @@ static_columns: {
   "study_arm": "SCAN",
   "primary_language": "Vietnamese",
 }
+relabel_zipcodes: True
 
 ---
 name: SCAN IRB Russian
@@ -201,6 +204,7 @@ static_columns: {
   "study_arm": "SCAN",
   "primary_language": "Russian",
 }
+relabel_zipcodes: True
 
 ---
 name: SCAN IRB Traditional Chinese
@@ -220,6 +224,7 @@ static_columns: {
   "study_arm": "SCAN",
   "primary_language": "Traditional Chinese",
 }
+relabel_zipcodes: True
 
 ---
 name: EH&S Data Transer for Husky Coronavirus Testing
@@ -272,6 +277,7 @@ column_rename_map: {
 static_columns: {
   "study_arm": "SCAN",
 }
+relabel_zipcodes: True
 
 ---
 name: Seattle Flu Study - Shelters Intervention


### PR DESCRIPTION
I was using the id3c-customizations `zipcode_map()` function to convert
REDCap raw zipcode labels to their real zipcode equivalent. However, HCT
zipcodes (at least in the EH&S project) are already the real zipcode. I
overlooked the fact that the `zipcode_map()` function returns None if
the input data don't exist in the map. This commit preserves the
original zipcode if no appropriate mapping was found (rather than
overwriting it with None).