### PR TITLE
redcap-data-dictionary: Rename id3c.cli methods

### DIFF
--- a/bin/redcap-data-dictionary/download-data-dictionary
+++ b/bin/redcap-data-dictionary/download-data-dictionary
@@ -37,7 +37,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     project = redcap.Project(os.environ['REDCAP_API_URL'], args.project_id)
-    data_dictionary = project.metadata()
+    data_dictionary = project.fields
 
     if args.output:
         with open(args.output, 'w') as outfile:

--- a/bin/redcap-data-dictionary/upload-data-dictionary
+++ b/bin/redcap-data-dictionary/upload-data-dictionary
@@ -159,4 +159,4 @@ if __name__ == '__main__':
 
     dry_run = not args.import_to_redcap
     project = redcap.Project(os.environ['REDCAP_API_URL'], args.project_id, dry_run=dry_run)
-    project.update_metadata(new_data_dictionary)
+    project.update_fields(new_data_dictionary)


### PR DESCRIPTION
In a new ID3C PR (209), we change the `redcap.metadata` and
`redcap.update_metadata` methods to use the term "fields" instead of
"metadata". Update the backoffice code accordingly.

-------------

Depends on https://github.com/seattleflu/id3c/pull/209