### PR TITLE
Add longitudinal mapping

### DIFF
--- a/bin/return-of-results/export-redcap-sfs-classic
+++ b/bin/return-of-results/export-redcap-sfs-classic
@@ -113,10 +113,9 @@ def fetch_records(project) -> List[Dict[str, dict]]:
 
     if project.contacted_field:
         fields.add(project.contacted_field)
-        required_fields.add(project.contacted_field)
 
     for record in project.records(fields = fields, raw = True):
-        if not all(len(record[field]) for field in required_fields):
+        if len(required_fields) > 0 and not all(len(record[field]) for field in required_fields):
             continue
 
         # Standardize the name of some keys

--- a/bin/return-of-results/export-redcap-sfs-longitudinal
+++ b/bin/return-of-results/export-redcap-sfs-longitudinal
@@ -8,22 +8,25 @@
 # The $CONFIG file is expected to have at least one YAML document in it with
 # the following format:
 #
-#   ---
-#   redcap:
-#       url: https://redcap.iths.org
-#       project: 23854
-#   source: uw_reopening
-#   enrollment_event_names:
-#     - enrollment_arm_1
-#   enrollment_fields:
-#     - core_participant_first_name
-#     - core_participant_last_name
-#     - core_birthdate
-#   encounter_event_names:
-#     - encounter_arm_1
-#   encounter_fields:
-#     - collect_barcode_kiosk
-#     - return_utm_barcode
+# ---
+# redcap:
+#   url: https://redcap.iths.org
+#   project: 23854
+# source: uw_reopening
+# contact_before_releasing_result: false
+# contacted_field: null
+# participant_first_name_field: core_participant_first_name
+# participant_last_name_field: core_participant_last_name
+# participant_birthdate_field: core_birthdate
+# enrollment_event_names:
+#   - enrollment_arm_1
+# encounter_event_names:
+#   - encounter_arm_1
+# additional_fields:
+#  - {"name":"ordering_provider", "required": true}
+# prioritized_barcode_fields:
+#   - collect_barcode_kiosk
+#   - return_utm_barcode
 #
 import sys
 import json
@@ -42,18 +45,30 @@ if not config_file:
 
 class SFSProject(Project):
     source: str
+    contact_before_releasing_result: bool
+    contacted_field: str
+    participant_first_name_field: str
+    participant_last_name_field: str
+    participant_birthdate_field: str
     enrollment_event_names: List[str]
-    enrollment_fields: List[str]
     encounter_event_names: List[str]
-    encounter_fields: List[str]
+    additional_fields: List[Dict[str, Any]]
+    prioritized_barcode_fields: List[str]
+
 
     def __init__(self, config: Dict[str, Any]):
         super().__init__(config['redcap']['url'], config['redcap']['project'])
         self.source = config['source']
+        self.contact_before_releasing_result = config['contact_before_releasing_result']
+        self.contacted_field = config.get('contacted_field')
+        self.participant_first_name_field = config['participant_first_name_field']
+        self.participant_last_name_field = config['participant_last_name_field']
+        self.participant_birthdate_field = config['participant_birthdate_field']
         self.enrollment_event_names = config['enrollment_event_names']
-        self.enrollment_fields = config['enrollment_fields']
         self.encounter_event_names = config['encounter_event_names']
-        self.encounter_fields = config['encounter_fields']
+        self.additional_fields = config.get('additional_fields') or []
+        self.prioritized_barcode_fields = config['prioritized_barcode_fields']
+
 
 
 def main():
@@ -63,18 +78,41 @@ def main():
     for config in configs:
         project = SFSProject(config)
 
+        assert (not project.contact_before_releasing_result or (project.contact_before_releasing_result and project.contacted_field)), \
+        "If the project requires contact before releasing the result, you must specify the `contacted_field` field. Correct the project " \
+        f"with source: {project.source}."
+
         enrollment_records = fetch_enrollment_records(project)
 
         # Update encounter data with enrollment data based on record.id
         # Skip the record if it does not have enrollment data
         for record in fetch_encounter_records(project):
             enrollment_data = enrollment_records.get(record.id)
+
             if not enrollment_data:
                 continue
 
             record.update(enrollment_data)
             record['source'] = project.source
-            print(json.dumps(record, indent = None, separators = ",:"), flush = True)
+            record['contact_before_releasing_result'] = str(project.contact_before_releasing_result).lower()
+
+            barcode = None
+
+            for field in project.prioritized_barcode_fields:
+                if record.get(field):
+                    barcode = record[field]
+                    break
+
+            record['prioritized_barcode'] = barcode
+
+            # Use the record only if it has the necessary barcode fields populated
+            if barcode:
+
+                # Don't retain the raw barcode fields now that we have the prioritized one
+                for field in project.prioritized_barcode_fields:
+                    del record[field]
+
+                print(json.dumps(record, indent = None, separators = ",:"), flush = True)
 
 
 def fetch_enrollment_records(project) -> Dict[str, dict]:
@@ -89,15 +127,20 @@ def fetch_enrollment_records(project) -> Dict[str, dict]:
     redcap_records: Dict[str,dict] = {}
     duplicate_record_ids = set()
 
-    fields = [project.record_id_field] + project.enrollment_fields
+    fields = [project.record_id_field, project.participant_first_name_field,
+        project.participant_last_name_field, project.participant_birthdate_field]
+
     for record in project.records(events = project.enrollment_event_names, fields = fields, raw = True):
-        if not all(len(record[field]) for field in project.enrollment_fields):
+        if not all(len(record[field]) for field in fields):
             continue
 
         if record.id in redcap_records:
             duplicate_record_ids.add(record.id)
 
-        redcap_records[record.id] = { field: record[field] for field in project.enrollment_fields }
+        redcap_records[record.id] = {'core_participant_first_name' : record[project.participant_first_name_field],
+            'core_participant_last_name': record[project.participant_last_name_field],
+            'core_participant_birth_date': record[project.participant_birthdate_field]
+            }
 
     if duplicate_record_ids:
         for record_id in duplicate_record_ids:
@@ -115,10 +158,25 @@ def fetch_encounter_records(project):
     Only include the encounter record if at least one of the
     *project.encounter_fileds* is completed.
     """
-    fields = [project.record_id_field] + project.encounter_fields
+    fields = {project.record_id_field, *project.prioritized_barcode_fields,
+        *[entry['name'] for entry in project.additional_fields]}
+
+    required_fields = {*[entry['name'] for entry \
+        in project.additional_fields if entry['required'] == True]
+        }
+
+    if project.contacted_field:
+        fields.add(project.contacted_field)
+
     for record in project.records(events = project.encounter_event_names, fields = fields, raw = True):
-        if not any(len(record[field]) for field in project.encounter_fields):
+        if len(required_fields) > 0 and not any(len(record[field]) for field in required_fields):
             continue
+
+        if project.contacted_field:
+            record['participant_contacted'] = record.pop(project.contacted_field)
+        else:
+            # Use "" to match a REDCap unset variable
+            record['participant_contacted'] = ""
 
         yield record
 

--- a/bin/return-of-results/transform
+++ b/bin/return-of-results/transform
@@ -93,51 +93,9 @@ def parse_scan_redcap(redcap_file) -> pd.DataFrame:
     return redcap_data[['qrcode', 'pat_name', 'birth_date', 'contacted', 'source']]
 
 
-def parse_sfs_longitudinal_redcap(redcap_file) -> pd.DataFrame:
+def parse_configuration_driven_redcap(redcap_file) -> pd.DataFrame:
     """
-    Reads in data from a given SFS longitudinal *redcap_file*. Returns a
-    pandas.DataFrame prepared in the specifications of UW Lab Med's return
-    of results portal.
-    """
-    redcap_data = (
-        pd.read_json(redcap_file, lines = True, dtype = False, convert_dates = False)
-        .astype("string")
-        .pipe(trim_whitespace)
-        .replace({"": pd.NA})
-        .astype("string")
-        .rename(columns={"core_birthdate": "birth_date"})
-    )
-
-    participant_name = lambda row: f"{row['core_participant_first_name']} {row['core_participant_last_name']}"
-    redcap_data['pat_name'] = redcap_data.apply(participant_name, axis='columns')
-
-    # This invariant protects our filename assumptions.
-    assert all(redcap_data['birth_date'].str.match(r"^\d{4}-\d{2}-\d{2}$").dropna())
-
-    # Normalize all barcode fields upfront.
-    barcode_fields = {
-        "collect_barcode_kiosk",
-        "return_utm_barcode"}
-
-    for barcode_field in barcode_fields:
-        redcap_data[barcode_field] = normalize_barcode(redcap_data[barcode_field])
-
-    kiosk_barcodes = redcap_data["collect_barcode_kiosk"]
-    mail_barcodes = redcap_data["return_utm_barcode"]
-
-    barcodes = kiosk_barcodes.combine_first(mail_barcodes)
-
-    barcodes = drop_duplicate_barcodes(barcodes)
-
-    redcap_data['qrcode'] = barcodes
-    redcap_data.loc[redcap_data['source'] == 'uw_reopening', 'contacted'] = pd.NA
-
-    return redcap_data[['qrcode', 'pat_name', 'birth_date', 'contacted', 'source']]
-
-
-def parse_sfs_classic_redcap(redcap_file) -> pd.DataFrame:
-    """
-    Reads in data from a given SFS classic *redcap_file*. Returns a
+    Reads in data from a given configuration driven *redcap_file*. Returns a
     pandas.DataFrame prepared in the specifications of UW Lab Med's return
     of results portal.
     """
@@ -160,6 +118,10 @@ def parse_sfs_classic_redcap(redcap_file) -> pd.DataFrame:
     barcodes = redcap_data['prioritized_barcode']
     barcodes = drop_duplicate_barcodes(barcodes)
     redcap_data['qrcode'] = barcodes
+
+    # The longitudinal parser currently does not return `ordering_provider`
+    if not 'ordering_provider' in redcap_data.columns:
+        redcap_data['ordering_provider'] = pd.NA
 
     return redcap_data[['qrcode', 'pat_name', 'birth_date', 'contacted', 'source', 'contact_before_releasing_result', 'ordering_provider']]
 
@@ -216,8 +178,7 @@ def edit_status_code(results: pd.DataFrame) -> pd.DataFrame:
     # To prevent a row's `require_contacted` value from getting set as pd.NA and then failing where we compare
     # its value with the boolean values of the other series (is_positive, is_inconclusive, participant_contacted),
     # first check that the value is not pd.NA before comparing its string value.
-    require_contacted_lambda = lambda row: (row['source'] is not pd.NA and row['source'] \
-        in ['scan', 'childcare', 'snohomish_schools', '2021_childcare']) \
+    require_contacted_lambda = lambda row: (row['source'] is not pd.NA and row['source'] == 'scan') \
         or (row['contact_before_releasing_result'] is not pd.NA and row['contact_before_releasing_result'] == 'true')
     require_contacted = results.apply(require_contacted_lambda, axis='columns')
 
@@ -263,8 +224,8 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     scan_redcap_data = parse_scan_redcap(args.scan_redcap_data)
-    sfs_longitudinal_redcap_data = parse_sfs_longitudinal_redcap(args.sfs_longitudinal_redcap_data)
-    sfs_classic_redcap_data = parse_sfs_classic_redcap(args.sfs_classic_redcap_data)
+    sfs_longitudinal_redcap_data = parse_configuration_driven_redcap(args.sfs_longitudinal_redcap_data)
+    sfs_classic_redcap_data = parse_configuration_driven_redcap(args.sfs_classic_redcap_data)
 
     # Combine the DataFrames by appending to the first.
     # Use `ignore_index = True` to prevent duplicate index values.

--- a/etc/sfs-longitudinal-redcap-projects.yaml
+++ b/etc/sfs-longitudinal-redcap-projects.yaml
@@ -3,15 +3,16 @@ redcap:
   url: https://redcap.iths.org
   project: 23854
 source: uw_reopening
+contact_before_releasing_result: false
+contacted_field: null
+participant_first_name_field: core_participant_first_name
+participant_last_name_field: core_participant_last_name
+participant_birthdate_field: core_birthdate
 enrollment_event_names:
   - enrollment_arm_1
-enrollment_fields:
-  - core_participant_first_name
-  - core_participant_last_name
-  - core_birthdate
 encounter_event_names:
   - encounter_arm_1
-encounter_fields:
+prioritized_barcode_fields:
   - collect_barcode_kiosk
   - return_utm_barcode
 ---
@@ -19,13 +20,14 @@ redcap:
   url: https://redcap.iths.org
   project: 23740
 source: childcare
+contact_before_releasing_result: true
+contacted_field: contacted
+participant_first_name_field: core_participant_first_name
+participant_last_name_field: core_participant_last_name
+participant_birthdate_field: core_birthdate
 enrollment_event_names:
   - enrollment_arm_1
   - enrollment_arm_2
-enrollment_fields:
-  - core_participant_first_name
-  - core_participant_last_name
-  - core_birthdate
 encounter_event_names:
   - week1_mon_test_arm_1
   - week1_thur_test_arm_1
@@ -46,21 +48,21 @@ encounter_event_names:
   - unscheduled_arm_1
   - enrollment_arm_2
   - week_2_arm_2
-encounter_fields:
+prioritized_barcode_fields:
   - return_utm_barcode
-  - contacted
 ---
 redcap:
   url: https://redcap.iths.org
   project: 27574
 source: snohomish_schools
+contact_before_releasing_result: true
+contacted_field: contacted
+participant_first_name_field: core_participant_first_name
+participant_last_name_field: core_participant_last_name
+participant_birthdate_field: core_birthdate
 enrollment_event_names:
   - enrollment_arm_1
   - enrollment_arm_2
-enrollment_fields:
-  - core_participant_first_name
-  - core_participant_last_name
-  - core_birthdate
 encounter_event_names:
   - week_1_arm_1
   - week_2_arm_1
@@ -78,22 +80,22 @@ encounter_event_names:
   - week_14_arm_1
   - week_15_arm_1
   - week_2_arm_2
-encounter_fields:
+prioritized_barcode_fields:
   - collect_barcode_kiosk
   - return_utm_barcode
-  - contacted
 ---
 redcap:
   url: https://redcap.iths.org
   project: 29351
 source: 2021_childcare
+contact_before_releasing_result: true
+contacted_field: contacted
+participant_first_name_field: core_participant_first_name
+participant_last_name_field: core_participant_last_name
+participant_birthdate_field: core_birthdate
 enrollment_event_names:
   - enrollment_arm_1
   - enrollment_arm_2
-enrollment_fields:
-  - core_participant_first_name
-  - core_participant_last_name
-  - core_birthdate
 encounter_event_names:
   - week1_test_1_arm_1
   - week1_test_2_arm_1
@@ -131,6 +133,5 @@ encounter_event_names:
   - week17_test_2_arm_1
   - unscheduled_arm_1
   - week_2_arm_2
-encounter_fields:
+prioritized_barcode_fields:
   - return_utm_barcode
-  - contacted

--- a/etc/sfs-longitudinal-redcap-projects.yaml
+++ b/etc/sfs-longitudinal-redcap-projects.yaml
@@ -135,3 +135,24 @@ encounter_event_names:
   - week_2_arm_2
 prioritized_barcode_fields:
   - return_utm_barcode
+---
+redcap:
+  url: https://redcap.iths.org
+  project: 24499
+source: apple_respiratory
+contact_before_releasing_result: true
+contacted_field: contacted
+participant_first_name_field: core_participant_first_name
+participant_last_name_field: core_participant_last_name
+participant_birthdate_field: core_birthdate
+enrollment_event_names:
+  - enrollment_arm_1
+encounter_event_names:
+  - baseline_test_arm_1
+  - illness_episode_arm_1
+  - serial_event_1_arm_1
+  - serial_event_2_arm_1
+  - serial_event_3_arm_1
+  - serial_event_4_arm_1
+prioritized_barcode_fields:
+  - collection_barcode


### PR DESCRIPTION
The bulk of this PR is adding field mapping and barcode prioritization logic to the SFS longitudinal configuration driven parser to match what was put in for the classic mode. This accommodates REDCap projects that use fields that aren't named like other projects and explicitly configures whether the project requires contact the participant before releasing positive results.
A commit fixes two small bugs in the classic mode.
A commit adds longitudinal configuration for the Apple Respiratory Study.

For testing, I ran `generate-results-csv` using this version of the code and right after using the master version of the code. A diff revealed no differences.