### PR TITLE
Update crontab to run childcare etl for 2021 project

### DIFF
--- a/crontabs/id3c-production
+++ b/crontabs/id3c-production
@@ -108,10 +108,10 @@ GEOCODING_CACHE=/home/ubuntu/scan-cache.pickle
 GEOCODING_CACHE=/home/ubuntu/uw-reopening-cache.pickle
 */10 * * * * ubuntu promjob "id3c etl redcap-det uw-reopening" flock -F $GEOCODING_CACHE envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap pipenv run id3c etl redcap-det uw-reopening --redcap-api-batch-size 150 --det-limit 1000 --commit
 
-# Ingest Childcare REDCap project every 30 min (after UW Reopening project above).
+# Ingest Childcare 2021 REDCap project every 30 min (after UW Reopening project above).
 # Use redcap-api-batch-size = 1000 because this REDCap project is longitudinal.
 GEOCODING_CACHE=/home/ubuntu/sfs-cache.pickle
-21,51 * * * * ubuntu promjob "id3c etl redcap-det childcare" flock -F $GEOCODING_CACHE envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap pipenv run id3c etl redcap-det childcare --redcap-api-batch-size 1000 --commit
+21,51 * * * * ubuntu promjob "id3c etl redcap-det childcare-2021" flock -F $GEOCODING_CACHE envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap pipenv run id3c etl redcap-det childcare-2021 --redcap-api-batch-size 1000 --commit
 
 # Ingest FHIR documents every 5 minutes.
 */5  * * * * ubuntu fatigue --quiet promjob "id3c etl fhir" pipenv run id3c etl fhir --commit


### PR DESCRIPTION
The childcare project is transitioning from the pilot to a 2021 version.
Update the id3c-production cron tab to replace exisiting with the new
etl command. The command name change is because its a different project, 
and the existing etl command is left in place to be run manually if needed.