### PR TITLE
generate-results-csv: Kill all failed processes

### DIFF
--- a/bin/return-of-results/generate-results-csv
+++ b/bin/return-of-results/generate-results-csv
@@ -23,7 +23,7 @@ main() {
     # Change to the ./bin/return-of-results directory in the backoffice checkout
     cd "$(dirname "$0")"
 
-    ./transform <(./export-redcap-scan) <(./export-redcap-sfs-longitudinal) <(./export-redcap-sfs-classic) <(./export-id3c-return-results || kill $$)
+    ./transform <(./export-redcap-scan || kill $$) <(./export-redcap-sfs-longitudinal || kill $$) <(./export-redcap-sfs-classic || kill $$) <(./export-id3c-return-results || kill $$)
 }
 
 print-help() {


### PR DESCRIPTION
Handle all process substitutions similarly, instructing the child
process to kill the parent in case it fails. This introduces a race
condition where the parent process will no longer be around for the non-
winning processes.

------------------------------

Addresses post-merge feedback from https://github.com/seattleflu/backoffice/pull/111.