### PR TITLE
Process REDCap data in chunks for the EH&S Transfer

### DIFF
--- a/bin/uw-ehs-report/generate-report
+++ b/bin/uw-ehs-report/generate-report
@@ -12,6 +12,8 @@ set -euo pipefail
 
 : "${REDCAP_API_URL:?The REDCAP_API_URL environment variable is required.}"
 
+base="$(dirname "$0")/../.."
+
 main() {
     for arg; do
         case "$arg" in
@@ -21,10 +23,18 @@ main() {
         esac
     done
 
+    datadir="$(TMPDIR="$base" mktemp -d -t ehs-export-XXXXXX)"
+
+    # Always leave and delete this temporary directory regardless of exit code
+    trap "rm -rf '$datadir'" EXIT
+
     # Change to the ./bin/uw_ehs_report directory in the backoffice checkout
     cd "$(dirname "$0")"
 
-    ./transform <(./export-redcap-uw-reopening) <(./export-id3c-uw-ehs-report)
+    ./export-redcap-uw-reopening > "$datadir/redcap_data.ndjson"
+    ./export-id3c-uw-ehs-report > "$datadir/id3c_results.csv"
+
+    ./transform "$datadir/redcap_data.ndjson" "$datadir/id3c_results.csv"
 }
 
 print-help() {

--- a/bin/uw-ehs-report/transform
+++ b/bin/uw-ehs-report/transform
@@ -4,60 +4,17 @@ Join the REDCap NDJSON data with an ID3C CSV.
 Prepares the joined data for import into the
 EH&S Transfer REDCap project.
 """
-import sys
+
 import argparse
+import io
+import json
 import pandas as pd
+import sys
+from typing import List
+
 from id3c.cli.io.pandas import dump_ndjson
 
-
-def parse_redcap(redcap_file) -> pd.DataFrame:
-    """
-    Reads in data from a given *redcap_file*. Returns a pandas.DataFrame
-    with columns renamed for the EH&S import.
-    """
-    redcap_data = (
-        pd.read_json(redcap_file, lines = True, dtype = False, convert_dates = False)
-        .astype("string")
-        .pipe(trim_whitespace)
-        .replace({"": pd.NA})
-        .astype("string")
-        .rename(columns={"dorm_room": "uw_dorm_room_number",
-        "sea_employee_type_other": "employee_category_other",
-        "dorm": "uw_dorm_name",
-        "uw_apt_names": "uw_apartment_name",
-        "core_participant_first_name": "participant_first_name",
-        "core_participant_last_name": "participant_last_name",
-        "core_birthdate": "birthdate",
-        "core_home_street": "home_street",
-        "core_apartment_number": "apartment_number",
-        "core_home_city": "home_city",
-        "core_home_state": "home_state",
-        "core_zipcode": "zipcode",
-        "pronouns_other": "preferred_pronouns_other",
-        "core_sex_other": "sex_other"
-        }))
-
-
-    # Normalize all barcode fields upfront.
-    barcode_fields = {
-        "collect_barcode_kiosk",
-        "return_utm_barcode"}
-
-    for barcode_field in barcode_fields:
-        if barcode_field in redcap_data:
-            redcap_data[barcode_field] = normalize_barcode(redcap_data[barcode_field])
-        else:
-            redcap_data[barcode_field] = pd.Series(dtype = "string")
-
-    kiosk_barcodes = redcap_data["collect_barcode_kiosk"]
-    mail_barcodes = redcap_data["return_utm_barcode"]
-
-    barcodes = kiosk_barcodes.combine_first(mail_barcodes)
-    barcodes = drop_duplicate_values(barcodes)
-    redcap_data['barcode'] = barcodes
-
-    enrollments = redcap_data.query('redcap_event_name == "enrollment_arm_1"')[[ \
-        "record_id",
+ENROLL_FIELDS =  [
         "netid",
         "affiliation_other",
         "uw_school",
@@ -79,82 +36,18 @@ def parse_redcap(redcap_file) -> pd.DataFrame:
         "sex_other",
         "uw_greek_house",
         "uw_dorm_name",
-        "uw_apartment_name"
-        ]]
+        "uw_apartment_name"]
 
-    # This invariant protects our filename assumptions.
-    assert all(enrollments['birthdate'].str.match(r"^\d{4}-\d{2}-\d{2}$").dropna())
-
-    # Drop enrollment records with duplicated NetIDs.
-    netids = enrollments['netid']
-    netids = drop_duplicate_values(netids)
-    enrollments['netid'] = netids
-    enrollments.dropna(subset={'netid'}, inplace=True)
-
-    encounters = redcap_data.query('redcap_event_name == "encounter_arm_1"')[[ \
-        'record_id',
-        'barcode',
-        'illness_kiosk',
-        'illness_swabsend'
-        ]]
-
-    # Set symptomatic_when_tested on encounters.
-    # Use '1' and '0' values to be consistent with the other boolean values we send to REDCap.
-    encounters.loc[(encounters['illness_kiosk'] == 'yes') | (encounters['illness_swabsend'] == 'yes'), 'symptomatic_when_tested'] = '1'
-    encounters.loc[(encounters['illness_kiosk'] == 'no') | (encounters['illness_swabsend'] == 'no'), 'symptomatic_when_tested'] = '0'
-
-    joined_data = enrollments.merge(encounters, how='inner', on='record_id')
-
-    return joined_data
+# The number of lines to read from the REDCap file in one batch
+BATCH_SIZE = 10000
 
 
-def normalize_barcode(barcode):
-    if barcode.empty:
-        return pd.NA
-    return barcode.str.upper().str.strip()
-
-
-def trim_whitespace(df: pd.DataFrame) -> pd.DataFrame:
+def prepare_id3c_data(id3c_data_path: str) -> pd.DataFrame:
     """
-    Trim leading and trailing whitespace from strings in *df*.
+    Reads the file containing results data from ID3C.
+    Prepares the data for joining to REDCap data later.
     """
-    str_columns = df.select_dtypes("string").columns
-    df[str_columns] = df[str_columns].apply(lambda column: column.str.strip())
-    return df
-
-def drop_duplicate_values(input_series: pd.Series) -> pd.Series:
-    """
-    Find and drop duplicate values from the provided series and returns
-    the deduplicated pandas Series.
-    Avoids printing PII only if the given *input_series.name* is `netid`.
-    """
-    deduplicated_series = input_series
-
-    dups = input_series.loc[input_series.duplicated(keep = False)].dropna()
-    if not dups.empty:
-        deduplicated_series = input_series.drop(dups.index, inplace = False)
-
-        dups_count = len(dups)
-        dups_unique = list(dups.unique())
-        print(f"Dropped {dups_count:,} records with duplicated {input_series.name}: "
-            f"{dups_unique if input_series.name != 'netid' else '<masked>'}", file = sys.stderr)
-
-    return deduplicated_series
-
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(
-        description="Join a REDCAP export NDJSON file with a SCAN return of results ID3C export CSV file."
-    )
-    parser.add_argument("redcap_data", help="NDJSON export of SCAN records from REDCap")
-    parser.add_argument("id3c_data", help="CSV export of SCAN return of results from ID3C")
-    parser.add_argument("output", help="A destination for the output NDJSON", nargs="?",
-        default=sys.stdout, type=argparse.FileType("w"))
-
-    args = parser.parse_args()
-
-    redcap_data = parse_redcap(args.redcap_data)
-
-    id3c_data = pd.read_csv(args.id3c_data, dtype = 'string')
+    id3c_data = pd.read_csv(id3c_data_path, dtype = 'string')
     id3c_data['barcode'] = normalize_barcode(id3c_data['barcode'])
 
     # Drop id3c records with duplicated barcodes
@@ -178,13 +71,168 @@ if __name__ == '__main__':
     for field in boolean_fields:
         id3c_data[field].replace({'t': 1, 'f': 0}, inplace=True)
 
-    # Only keep records we can match from both REDCap and ID3C.  An incorrect
-    # barcode in REDCap or the lack of a record in ID3C may cause records to
-    # drop out in the join, but this is preferable to attaching results to an
-    # incorrect barcode or not having a known status for a barcode.
-    joined_data = redcap_data.merge(id3c_data, how='inner', on='barcode')
+    return id3c_data
 
 
+def find_duplicate_netids(redcap_file: str) -> List[str]:
+    """
+    From the *redcap_file* finds all NetIDs that are associated with
+    more than one record_id.
+    """
+    found_netids = {}
+    duplicates = []
+
+    with open(redcap_file, 'r') as f:
+        for line in f:
+            line_json = json.loads(line)
+            if line_json['netid']: # Only enrollment records have netid populated
+
+                if line_json['netid'] in found_netids:
+
+                    if found_netids[line_json['netid']] != line_json['record_id']:
+                        duplicates.append(line_json['netid'])
+
+                else:
+                    found_netids[line_json['netid']] = line_json['record_id']
+
+    return duplicates
+
+
+def process_redcap_data_and_dump_output(redcap_file: str, id3c_data: pd.DataFrame,
+        output: argparse.FileType) -> None:
+    """
+    Reads the file containing REDCap data in batches.
+    Joins each REDCap batch with ID3C data and writes the joined
+    data as ndjson.
+    """
+    duplicate_netids = find_duplicate_netids(redcap_file)
+    if len(duplicate_netids) > 0:
+        # Don't log the actual NetIDs to protect privacy.
+        print(f"Found {len(duplicate_netids)} NetIDs that belong to more than one record_id. "
+            f"These will be dropped from enrollments.", file = sys.stderr)
+
+    with open(redcap_file, "r") as file:
+        rows = []
+
+        for row in (json.loads(line) for line in file):
+            if len(rows) >= BATCH_SIZE and row["record_id"] != rows[-1]["record_id"]:
+                # We've made our batch size and are at a record boundary.  Process the
+                # current batch now.
+                process_redcap_batch_and_dump_output(rows, id3c_data, duplicate_netids, output)
+
+                # Start the next batch with the current row because it has not been processed yet.
+                rows = [row]
+
+            else:
+                rows.append(row)
+
+        # Pick up the last batch
+        if rows:
+            process_redcap_batch_and_dump_output(rows, id3c_data, duplicate_netids, output)
+
+
+def process_redcap_batch_and_dump_output(rows: List[dict], id3c_data: pd.DataFrame,
+        duplicate_netids: List[str], output: argparse.FileType) -> None:
+
+        redcap_data = (
+            pd.DataFrame.from_records(rows)
+            .astype("string")
+            .pipe(trim_whitespace)
+            .replace({"": pd.NA})
+            .astype("string")
+            .rename(columns={"dorm_room": "uw_dorm_room_number",
+            "sea_employee_type_other": "employee_category_other",
+            "dorm": "uw_dorm_name",
+            "uw_apt_names": "uw_apartment_name",
+            "core_participant_first_name": "participant_first_name",
+            "core_participant_last_name": "participant_last_name",
+            "core_birthdate": "birthdate",
+            "core_home_street": "home_street",
+            "core_apartment_number": "apartment_number",
+            "core_home_city": "home_city",
+            "core_home_state": "home_state",
+            "core_zipcode": "zipcode",
+            "pronouns_other": "preferred_pronouns_other",
+            "core_sex_other": "sex_other"
+            }))
+
+        # Normalize all barcode fields upfront.
+        barcode_fields = {
+            "collect_barcode_kiosk",
+            "return_utm_barcode"}
+
+        for barcode_field in barcode_fields:
+            if barcode_field in redcap_data:
+                redcap_data[barcode_field] = normalize_barcode(redcap_data[barcode_field])
+            else:
+                redcap_data[barcode_field] = pd.Series(dtype = "string")
+
+        kiosk_barcodes = redcap_data["collect_barcode_kiosk"]
+        mail_barcodes = redcap_data["return_utm_barcode"]
+
+        barcodes = kiosk_barcodes.combine_first(mail_barcodes)
+        barcodes = drop_duplicate_values(barcodes)
+        redcap_data['barcode'] = barcodes
+
+        enrollments = redcap_data.query('redcap_event_name == "enrollment_arm_1"')[[ \
+            "record_id",
+            "netid",
+            "affiliation_other",
+            "uw_school",
+            "employee_category_other",
+            "greek_other",
+            "participant_first_name",
+            "participant_last_name",
+            "birthdate",
+            "uw_dorm_room_number",
+            "phone_number",
+            "phone_number_2",
+            "email",
+            "home_street",
+            "apartment_number",
+            "home_city",
+            "home_state",
+            "zipcode",
+            "preferred_pronouns_other",
+            "sex_other",
+            "uw_greek_house",
+            "uw_dorm_name",
+            "uw_apartment_name"
+            ]]
+
+        # This invariant protects our filename assumptions.
+        assert all(enrollments['birthdate'].str.match(r"^\d{4}-\d{2}-\d{2}$").dropna())
+
+        # Drop enrollment records where the NetID was duplicated across record_ids.
+        enrollments = enrollments[~enrollments['netid'].isin(duplicate_netids)]
+
+        encounters = redcap_data.query('redcap_event_name == "encounter_arm_1"')[[ \
+            'record_id',
+            'barcode',
+            'illness_kiosk',
+            'illness_swabsend'
+            ]]
+
+        # Set symptomatic_when_tested on encounters.
+        # Use '1' and '0' values to be consistent with the other boolean values we send to REDCap.
+        encounters.loc[(encounters['illness_kiosk'] == 'yes') | (encounters['illness_swabsend'] == 'yes'), 'symptomatic_when_tested'] = '1'
+        encounters.loc[(encounters['illness_kiosk'] == 'no') | (encounters['illness_swabsend'] == 'no'), 'symptomatic_when_tested'] = '0'
+
+        encounters = enrollments.merge(encounters, how='inner', on='record_id')
+
+        # Only keep records we can match from both REDCap and ID3C.  An incorrect
+        # barcode in REDCap or the lack of a record in ID3C may cause records to
+        # drop out in the join, but this is preferable to attaching results to an
+        # incorrect barcode or not having a known status for a barcode.
+        encounters = encounters.merge(id3c_data, how='inner', on='barcode')
+
+        dump_joined_data(encounters, output)
+
+
+def dump_joined_data(joined_data: pd.DataFrame, output: argparse.FileType) -> None:
+    """
+    Writes the *joined_data* DataFrame as ndjson to the *output* file.
+    """
     dump_ndjson(joined_data[[ \
         'barcode', 'sample_collection_date', 'test_result', 'test_result_date',
 
@@ -205,4 +253,54 @@ if __name__ == '__main__':
         'uw_dorm_name', 'uw_dorm_room_number', 'lives_in_uw_apartment',
         'uw_apartment_name', 'study_tier', 'symptomatic_when_tested'
 
-        ]], file = args.output)
+        ]], file = output)
+
+
+def normalize_barcode(barcode):
+    if barcode.empty:
+        return pd.NA
+    return barcode.str.upper().str.strip()
+
+
+def trim_whitespace(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Trim leading and trailing whitespace from strings in *df*.
+    """
+    str_columns = df.select_dtypes("string").columns
+    df[str_columns] = df[str_columns].apply(lambda column: column.str.strip())
+    return df
+
+
+def drop_duplicate_values(input_series: pd.Series) -> pd.Series:
+    """
+    Find and drop duplicate values from the provided series and returns
+    the deduplicated pandas Series.
+    Avoids printing PII only if the given *input_series.name* is `netid`.
+    """
+    deduplicated_series = input_series
+
+    dups = input_series.loc[input_series.duplicated(keep = False)].dropna()
+    if not dups.empty:
+        deduplicated_series = input_series.drop(dups.index, inplace = False)
+
+        dups_count = len(dups)
+        dups_unique = list(dups.unique())
+        print(f"Dropped {dups_count:,} records with duplicated {input_series.name}: "
+            f"{dups_unique if input_series.name != 'netid' else '<masked>'}", file = sys.stderr)
+
+    return deduplicated_series
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="Join a REDCAP export NDJSON file with a SCAN return of results ID3C export CSV file."
+    )
+    parser.add_argument("redcap_data", help="NDJSON export of SCAN records from REDCap")
+    parser.add_argument("id3c_data", help="CSV export of SCAN return of results from ID3C")
+    parser.add_argument("output", help="A destination for the output NDJSON", nargs="?",
+        default=sys.stdout, type=argparse.FileType("w"))
+
+    args = parser.parse_args()
+
+    id3c_data = prepare_id3c_data(args.id3c_data)
+    process_redcap_data_and_dump_output(args.redcap_data, id3c_data, args.output)


### PR DESCRIPTION
Previously, the entire output file from the REDCap dump was loaded
at once. This was causing out of memory errors, as the working memory
grew past 9 GB. In this commit, the REDCap file is read in chunks and
the content of each chunk is processed completely as one batch. Peak
memory consumption as configured is around 3.5 GB.

The original `transform` script took about 51 seconds to process today's
data. This new version took slighly longer at 63 seconds.

I've tested by comparing the output generated by the master version of `transform` against this new version. There are no differences in the output.