### PR TITLE
Wrap refresh materialized view jobs into one job

### DIFF
--- a/bin/refresh-materialized-shipping-views
+++ b/bin/refresh-materialized-shipping-views
@@ -1,0 +1,59 @@
+#!/bin/bash
+# usage: ./bin/refresh-materialized-shipping-views
+#
+# Refreshes materialized views in the `shipping` schema
+# in the order configured.
+#
+
+set -euo pipefail
+
+
+# The materialized views to refresh.
+# They will get refreshed in the order listed.
+shipping_views=(
+    "fhir_questionnaire_responses_v1"
+    " __uw_encounters"
+    "scan_encounters_v1"
+    )
+
+
+main() {
+    for arg; do
+        case "$arg" in
+            -h|--help)
+                print-help
+                exit 0;;
+        esac
+    done
+
+    refresh-materialized-views
+}
+
+
+refresh-materialized-views() {
+
+    for view in "${shipping_views[@]}"; do
+        id3c refresh-materialized-view 'shipping' ${view} --commit
+    done
+
+}
+
+
+print-help() {
+    # Print the help comments at the top of this file ($0)
+    local line
+    while read -r line; do
+        if [[ $line =~ ^#! ]]; then
+            continue
+        elif [[ $line =~ ^# ]]; then
+            line="${line/##/}"
+            line="${line/# /}"
+            echo "$line"
+        else
+            break
+        fi
+    done < "$0"
+}
+
+
+main "$@"

--- a/crontabs/id3c-production
+++ b/crontabs/id3c-production
@@ -122,16 +122,11 @@ GEOCODING_CACHE=/home/ubuntu/sfs-cache.pickle
 * * * * * ubuntu fatigue --quiet promjob "terminate-idle-sessions" terminate-idle-sessions
 # Run the old metabase session disconnector routine every minute
 * * * * * ubuntu fatigue --quiet promjob "terminate-old-metabase-sessions" terminate-old-metabase-sessions
-# Run the refresh materialized view routine every 10 minutes include latest
-# ingested FHIR documents in the view
-*/10 * * * * ubuntu fatigue --quiet promjob "refresh-materialized-view: shipping.fhir_questionnaire_responses_v1" flock -F --nonblock --conflict-exit-code 0 "$FLOCK_DIR/shipping.fhir_questionnaire_responses_v1" pipenv run id3c refresh-materialized-view shipping fhir_questionnaire_responses_v1 --commit
-*/10 * * * * ubuntu fatigue --quiet promjob "refresh-materialized-view: shipping.scan_encounters_v1"              flock -F --nonblock --conflict-exit-code 0 "$FLOCK_DIR/shipping.scan_encounters_v1" pipenv run id3c refresh-materialized-view shipping scan_encounters_v1 --commit
 
-# Run the refresh materialized view routine for UW Reopening encounters every 10 minutes to include
-# latest data from other jobs, including refreshing the shipping.fhir_questionnaire_responses_v1 materialized view
-*/10 * * * * ubuntu fatigue --quiet promjob "refresh-materialized-view: shipping.__uw_encounters" flock -F --nonblock --conflict-exit-code 0 "$FLOCK_DIR/shipping.__uw_encounters" pipenv run id3c refresh-materialized-view shipping __uw_encounters --commit
+# Refresh materialized shipping views every 30 minutes to include
+# latest data, including latest ingested FHIR documents
+*/30 * * * * ubuntu fatigue --quiet promjob "refresh-materialized-shipping-views" flock -F --nonblock --conflict-exit-code 0 "$FLOCK_DIR/refresh_materialized_shipping_views" pipenv run refresh-materialized-shipping-views
 
 # Make UW Reopening testing offers at :15 and :45
-# This job uses data created by redcap-det uw-reopening, etl fhir, and refresh-materialized-view shipping fhir_questionnaire_responses_v1
-# Run at :15 to use the :00 uw-reopening run and :45 to use the :30 uw-reopening run
-15,45  * * * * ubuntu fatigue --quiet promjob "id3c offer-uw-testing" envdir $ENVD/redcap pipenv run id3c offer-uw-testing --commit
+# This job uses data created by redcap-det uw-reopening, etl fhir, and materialized shipping views.
+25,55  * * * * ubuntu fatigue --quiet promjob "id3c offer-uw-testing" envdir $ENVD/redcap pipenv run id3c offer-uw-testing --commit


### PR DESCRIPTION
The `__uw_encounters` and `scan_encounters_v1` materialized views depend
 on the `fhir_questionnaire_responses_v1` materialized view.

 This commit adds a new script that refreshes the materialized shipping
 views in the correct order and updates the production crontab to
 run this script instead of refreshing the materialized views
 individually.

 Currently, it takes about 10 minutes to materialize the 3 views in
 production. Therefore, the refresh job is configured to run every 30
 minutes. The start times of the `UW Reopening testing offers` job have
 been pushed back to allow the materialized views refresh to take
 up to 25 minutes.