### PR TITLE
production crontab: run at 5 AM instead of 4 AM

### DIFF
--- a/crontabs/id3c-production
+++ b/crontabs/id3c-production
@@ -53,8 +53,8 @@ FLOCK_DIR=/var/run/lock
 # Upload new UW retrospectives to REDCap once a day at midnight
 0 0 * * * ubuntu promjob "redcap-uw-retrospectives: import-to-redcap" pipenv run chronic envdir $ENVD/hutch/ envdir $ENVD/redcap import-uw-retrospectives-to-redcap --import
 
-# Create and upload REDCap DETs for UW retrospectives once a day at 4 A.M.
-0 4 * * * ubuntu promjob "redcap-uw-retrospectives: generate-and-upload-dets" pipenv run chronic envdir $ENVD/redcap generate-and-upload-uw-retro-redcap-dets
+# Create and upload REDCap DETs for UW retrospectives once a day at 5 A.M.
+0 5 * * * ubuntu promjob "redcap-uw-retrospectives: generate-and-upload-dets" pipenv run chronic envdir $ENVD/redcap generate-and-upload-uw-retro-redcap-dets
 
 # Run the manifest ETL 5 minutes after new manifest records are uploaded
 5-55/10 * * * * ubuntu fatigue --quiet promjob "id3c etl manifest" pipenv run id3c etl manifest --commit
@@ -77,13 +77,13 @@ FLOCK_DIR=/var/run/lock
 # Ingest SFS projects every hour, interleaving the projects so each get
 # ingested once every 8 hours. Keeping these in case any data corrections are made.
 # The uw-retro REDCap project is still active, but it only needs to be run
-# once a day after the DET generation at 4 A.M.
+# once a day after the DET generation at 5 A.M.
 GEOCODING_CACHE=/home/ubuntu/sfs-cache.pickle
 0 0-16/8 * * * ubuntu promjob "id3c etl redcap-det uw-retrospectives"        flock -F $GEOCODING_CACHE envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap pipenv run id3c etl redcap-det uw-retrospectives --commit
 0 1-17/8 * * * ubuntu promjob "id3c etl redcap-det swab-n-send"              flock -F $GEOCODING_CACHE envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap pipenv run id3c etl redcap-det swab-n-send --commit
 0 2-18/8 * * * ubuntu promjob "id3c etl redcap-det kiosk"                    flock -F $GEOCODING_CACHE envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap pipenv run id3c etl redcap-det kiosk --commit
 0 3-19/8 * * * ubuntu promjob "id3c etl redcap-det swab-and-home-flu"        flock -F $GEOCODING_CACHE envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap pipenv run id3c etl redcap-det swab-and-home-flu --commit
-0 4-20/8 * * * ubuntu promjob "id3c etl redcap-det asymptomatic-swab-n-send" flock -F $GEOCODING_CACHE envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap pipenv run id3c etl redcap-det asymptomatic-swab-n-send --commit
+0 5-21/8 * * * ubuntu promjob "id3c etl redcap-det asymptomatic-swab-n-send" flock -F $GEOCODING_CACHE envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap pipenv run id3c etl redcap-det asymptomatic-swab-n-send --commit
 
 # Ingest each SCAN Surveillance REDCap project every hour, interleaving the
 # projects so each gets ingested once every 8 hours.


### PR DESCRIPTION
The backoffice server is configured to reboot at 4 AM if it needs to
in order to install patches. For jobs that run only once a day at 4 AM,
run them at 5 AM instead to avoid getting skipped while the machine is
restarting.