### PR TITLE
Update UW retrospective manifest config with aliquot sheet 11

### DIFF
--- a/etc/uw-retrospectives-manifest.yaml
+++ b/etc/uw-retrospectives-manifest.yaml
@@ -198,3 +198,13 @@ extra_columns:
   mrn: mrn
   accession_no: accession
   sample_origin: sample_origin
+---
+workbook: s3://fh-pi-bedford-t/seattleflu/bbi/2020_2021_sfs_aliquoting_11.xlsx
+sheet: aliquoting
+sample_column: sample_id
+extra_columns:
+  barcode: sample_id
+  collection_date: collection_date
+  mrn: mrn
+  accession_no: accession
+  sample_origin: sample_origin


### PR DESCRIPTION
Lab is rolling over to aliquot manifest sheet 11, so start ingesting.