### PR TITLE
SCH retro pulls

### DIFF
--- a/bin/upload-sch-retrospective-data-pulls
+++ b/bin/upload-sch-retrospective-data-pulls
@@ -67,7 +67,7 @@ main() {
     do
         retrospective_ndjson_file="${retrospective_spreadsheet_file%.@(csv|xls|xlsx)}.ndjson"
 
-        echo "Checking for parsed retrospective data «$retrospective_ndjson_file»"
+        echo "Checking for parsed retrospective data «${retrospective_ndjson_file}»"
         if [[ -e "$retrospective_ndjson_file" ]]; then
             echo "Parsed data found. Continuing"
             echo

--- a/bin/upload-sch-retrospective-data-pulls
+++ b/bin/upload-sch-retrospective-data-pulls
@@ -49,7 +49,7 @@ main() {
     # Do not include SFS Year2 Main Data files prior to 2020. After the last
     # SCH data upload of 2019, the column naming scheme changed. The CLI command
     # was then changed, now causing earlier data pulls to fail on parsing.
-    glob_pattern="SFS_Year2_Main_Data_2020*"
+    glob_pattern="SFS_Year2_Main_Data_202[01]*"
 
     # Since the 2020-02-10 dataset, Amanda has only sent us Excel workbooks,
     # but preserve support for CSV too.


### PR DESCRIPTION
The latest uploads of SCH metadata include files with year 2021.
Add 2021 to the glob pattern for AWS files to include the latest files.