### PR TITLE
Automate linelist generation and upload to S3

### DIFF
--- a/bin/wa-doh-linelists/generate
+++ b/bin/wa-doh-linelists/generate
@@ -1,5 +1,5 @@
 #!/bin/bash
-# usage: ./bin/wa-doh-linelists/generate DATE
+# usage: ./bin/wa-doh-linelists/generate --date DATE
 #
 # Generates linelists for submission to WA DoH as a CSV.
 # Requires environment variables for the target REDCap projects specified in the
@@ -28,7 +28,7 @@ trap "rm -rf '$tmpdir'" EXIT
 echo "Exporting linelist data from ID3C"
 ./bin/wa-doh-linelists/export-id3c-hcov19-results "$date" > "$tmpdir"/id3c.csv
 
-echo "Combining ID3C data with REDCap report data"
+echo "Combining ID3C data with REDCap report data with args" "$@"
 pipenv run ./bin/wa-doh-linelists/transform \
     --id3c-data "$tmpdir"/id3c.csv \
-    --date "$date"
+    "$@"

--- a/bin/wa-doh-linelists/transform
+++ b/bin/wa-doh-linelists/transform
@@ -244,6 +244,6 @@ if __name__ == "__main__":
     mega_linelist = mega_linelist[universal_config['column_names']]
 
     mega_linelist.sort_values(by=['record_id']) \
-        .to_csv(args.output_dir / f"linelist_{date.replace('/', '')}.csv",
+        .to_csv(f"{args.output_dir}/linelist_{date.replace('/', '')}.csv",
             index=False,
             line_terminator='\r\n')

--- a/crontabs/id3c-production
+++ b/crontabs/id3c-production
@@ -130,3 +130,7 @@ GEOCODING_CACHE=/home/ubuntu/sfs-cache.pickle
 # Make UW Reopening testing offers at :15 and :45
 # This job uses data created by redcap-det uw-reopening, etl fhir, and materialized shipping views.
 25,55  * * * * ubuntu fatigue --quiet promjob "id3c offer-uw-testing" envdir $ENVD/redcap pipenv run id3c offer-uw-testing --commit
+
+# Generate and upload the previous day's linelist data once a day at 6 A.M.
+0 6 * * * ubuntu promjob "wa-doh-linelists" pipenv run envdir $ENVD/hutch envdir $ENVD/redcap wa-doh-linelists/generate
+--date $(date --date=yesterday --iso-8601=date) --output-dir "s3://fh-pi-bedford-t/seattleflu/public-health-reporting"


### PR DESCRIPTION
Use cron to generate daily linelists and upload to S3. Study staff can
then download the file from S3 to distribute to partner agencies,
instead of having to generate it locally.

This lets us control the environment for linelist generation and
simplifies the process for study staff. Eventually, it'd be great to
automatically upload the linelists directly to the partner agencies.