### PR TITLE
Exclude queries run by Metabase for sync/scan introspection from the slow-query killer

### DIFF
--- a/bin/terminate-slow-metabase-queries
+++ b/bin/terminate-slow-metabase-queries
@@ -11,6 +11,7 @@ psql --quiet --no-align --tuples-only --set ON_ERROR_STOP= <<<"
             pid != pg_backend_pid()
             and usename in ('metabase', 'metabase-privileged')
             and state = 'active'
+            and query like e'-- Metabase:: userID:%'
         order by
             active_duration desc
     ),


### PR DESCRIPTION
Otherwise some of these routine queries are not completing for very
field/value enumerations of very large and slow views.  We will
additionally reduce their cadence so they don't run as often.

Queries that are run on behalf of a user have an extended remark comment
at the beginning of the query indicating as much.¹  Positively select
for these to allow any non-user driven queries through.

¹ https://github.com/metabase/metabase/blob/b8c81d0277c509f37ade13a764eef5dc42a06fb6/src/metabase/query_processor/util.clj#L26-L37