### PR TITLE
Exclude queries run by Metabase for sync/scan introspection from the slow-query killer

### DIFF
--- a/bin/terminate-slow-metabase-queries
+++ b/bin/terminate-slow-metabase-queries
@@ -11,6 +11,7 @@ psql --quiet --no-align --tuples-only --set ON_ERROR_STOP= <<<"
             pid != pg_backend_pid()
             and usename in ('metabase', 'metabase-privileged')
             and state = 'active'
+            and metabase->'user_id' is not null
         order by
             active_duration desc
     ),

--- a/metabase/README.md
+++ b/metabase/README.md
@@ -19,6 +19,16 @@ service.  You may want to make a backup of the Metabase database first so that
 you can restore and rollback to the previous Metabase version if the upgrade
 corrupts the configuration.
 
+Before an upgrade, please review the [Metabase release
+notes](https://github.com/metabase/metabase/releases) for any backwards
+incompatible changes or other changes which might break the study team's usage
+of Metabase.
+
+In particular, it's worth checking if the format of Metabase's query
+remark/comment has changed.  Our `pg_stat_get_activity_nonsuperuser()` function
+parses the remark to provide additional metadata to our database connection
+watchdogs ([for example](https://github.com/seattleflu/id3c-customizations/commit/6f5db9ad)).
+
 ### Testing
 
 It's nice to test upgrades locally, particularly if there are significant


### PR DESCRIPTION
Otherwise some of these routine queries are not completing for very
field/value enumerations of very large and slow views.  We will
additionally reduce their cadence so they don't run as often.

Positively select only queries that are run on behalf of a user using
the new Metabase query details parsed from the query remark/comment by
the pg_stat_activity_nonsuperuser view.