### PR TITLE
Publish weekly pathogen prevalence data every day

### DIFF
--- a/bin/export-prevalence
+++ b/bin/export-prevalence
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -euo pipefail
+psql --no-psqlrc --quiet --set ON_ERROR_STOP= <<'SQL'
+    copy (
+        select
+            week,
+            organism,
+            present,
+            tested
+        from (
+            select
+                to_char(coalesce(collected, encountered)::date, 'IYYY-"W"IW') as week,
+
+                case
+                    when organism.lineage <@ 'Human_coronavirus.2019'
+                    then organism.lineage
+                    when organism.lineage <@ '{Human_parainfluenza, Human_coronavirus}'::ltree[]
+                    then subpath(organism.lineage, 0, 1)
+                    else organism.lineage
+                end as organism,
+
+                count(distinct sample_id) filter (where present) as present,
+                count(distinct sample_id) as tested
+
+            from warehouse.sample
+            left join warehouse.encounter using (encounter_id)
+            join warehouse.presence_absence using (sample_id)
+            join warehouse.target using (target_id)
+            join warehouse.organism using (organism_id)
+
+            where
+                (organism.lineage in
+                    ('Influenza.A.H1N1'
+                    ,'Influenza.A.H3N2'
+                    ,'Influenza.B'
+                    ,'RSV.A'
+                    ,'RSV.B'
+                    ,'Rhinovirus'
+                    ,'Adenovirus'
+                    ,'Human_metapneumovirus'
+                    ,'Human_coronavirus'
+                    ,'Human_parainfluenza'
+                    ) or organism.lineage <@ '{Human_parainfluenza, Human_coronavirus}'::ltree[])
+
+            group by week, organism
+            order by week asc, organism asc)
+        as
+            counts
+        where
+            week between '2018-W47' and to_char(current_date, 'IYYY-"W"IW')
+    )
+    to stdout
+    with (format csv, header);
+SQL

--- a/crontabs/Makefile
+++ b/crontabs/Makefile
@@ -3,6 +3,7 @@ CROND ?= /etc/cron.d
 
 crontabs := \
 	id3c-production \
+	public-datasets \
 	return-of-results \
 	scan-switchboard \
 	uw-ehs-report

--- a/crontabs/public-datasets
+++ b/crontabs/public-datasets
@@ -1,0 +1,15 @@
+SHELL=/bin/bash
+PATH=/opt/backoffice/bin:/usr/local/bin:/usr/bin:/bin
+
+# Point Pipenv at the production environment
+PIPENV_PIPFILE=/opt/backoffice/id3c-production/Pipfile
+
+LOG_CONFIG=/opt/backoffice/id3c-production/logging.yaml
+LOG_LEVEL=warning
+PGSERVICE=production-etl
+
+# Base of our env.d directories
+ENVD=/opt/backoffice/id3c-production/env.d
+
+
+0 4 * * * ubuntu export-prevalence | envdir $ENVD/aws/ aws s3 cp - s3://seattle-flu-study/prevalence.csv --content-type text/csv


### PR DESCRIPTION
This data file will power a chart of pathogen prevalence on
seattleflu.org.

The s3://seattle-flu-study bucket existed already and was previously
used for the samples.geojson file powering the heat map on
seattleflu.org.  I updated the backoffice-automation IAM group to allow
PUTs to this new file and also setup a CloudFront distribution for the
bucket served at https://data.seattleflu.org.