### PR TITLE
Reduce det-limit for UW Reopening ETL to 500 records

### DIFF
--- a/crontabs/id3c-production
+++ b/crontabs/id3c-production
@@ -108,7 +108,7 @@ GEOCODING_CACHE=/home/ubuntu/scan-cache.pickle
 
 # Ingest UW REopening REDCap project every 10 min
 GEOCODING_CACHE=/home/ubuntu/uw-reopening-cache.pickle
-*/10 * * * * ubuntu promjob "id3c etl redcap-det uw-reopening" flock -F $GEOCODING_CACHE envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap pipenv run id3c etl redcap-det uw-reopening --redcap-api-batch-size 75 --det-limit 1000 --commit
+*/10 * * * * ubuntu promjob "id3c etl redcap-det uw-reopening" flock -F $GEOCODING_CACHE envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap pipenv run id3c etl redcap-det uw-reopening --redcap-api-batch-size 75 --det-limit 500 --commit
 
 # Ingest Childcare 2021 REDCap project every 30 min (after UW Reopening project above).
 # Use redcap-api-batch-size = 1000 because this REDCap project is longitudinal.


### PR DESCRIPTION
Due to other issues, we fell behind in our typical processing of UW
re-opening/ HCT records. As such, we were processing closer to the
prior det limit of 1000 dets at a time, and were seeing OOM on the
host trying to process that many records at once. Typically, this
job had been running far below the set limit of 1000. Let's reduce
the job to process a max of 500 redcap DETs at a time.

Note: This should not be deployed before https://github.com/seattleflu/id3c/pull/232.
Backoffice production is currently intentionally rolled back a few commits behind master, and 
we should wait for the new pinning id3c's click dependency before deploying this branch to 
backoffice to keep the state of prod clean. 