### PR TITLE
Include residuals from PHSKC in our UW EHR data requests

### DIFF
--- a/bin/import-uw-retrospectives-to-redcap
+++ b/bin/import-uw-retrospectives-to-redcap
@@ -97,7 +97,7 @@ main() {
 
 parse-manifest() {
     id3c manifest parse-using-config "$CONFIG" \
-        | jq --compact-output 'select(.sample_origin | test("^(uwmc|hmc|nwh)_retro$"; "i"))'
+        | jq --compact-output 'select(.sample_origin | test("^(uwmc|hmc|nwh|phskc)_retro$"; "i"))'
 }
 
 diff-manifests() {


### PR DESCRIPTION
The lab does not currently record MRN and accession during specimen
intake, but the plan is to start soon.