### PR TITLE
crontabs: Reduce HCT Redcap API batch size from 75 to 60

### DIFF
--- a/crontabs/id3c-production
+++ b/crontabs/id3c-production
@@ -108,7 +108,7 @@ GEOCODING_CACHE=/home/ubuntu/scan-cache.pickle
 
 # Ingest UW REopening REDCap project every 10 min
 GEOCODING_CACHE=/home/ubuntu/uw-reopening-cache.pickle
-*/10 * * * * ubuntu promjob "id3c etl redcap-det uw-reopening" flock -F $GEOCODING_CACHE envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap pipenv run id3c etl redcap-det uw-reopening --redcap-api-batch-size 75 --det-limit 500 --commit
+*/10 * * * * ubuntu promjob "id3c etl redcap-det uw-reopening" flock -F $GEOCODING_CACHE envdir $ENVD/deidentification envdir $ENVD/smartystreets envdir $ENVD/redcap pipenv run id3c etl redcap-det uw-reopening --redcap-api-batch-size 60 --det-limit 500 --commit
 
 # Ingest Childcare 2021 REDCap project every 30 min (after UW Reopening project above).
 # Use redcap-api-batch-size = 1000 because this REDCap project is longitudinal.


### PR DESCRIPTION
We are again getting 500 responses again from Redcap's API when we try
to pull records, using 75 records at a time for the HCT project.

I reproduced locally and then reduced to 60 and saw successful responses
from the Redcap API.