### PR TITLE
Run pathogen prevalence job under promjob

### DIFF
--- a/bin/upload-prevalence
+++ b/bin/upload-prevalence
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+: ${S3_DST:=s3://seattle-flu-study/prevalence.csv}
+
+bin="$(dirname "$0")"
+
+"$bin"/export-prevalence | aws s3 cp - "$S3_DST" --content-type text/csv

--- a/crontabs/public-datasets
+++ b/crontabs/public-datasets
@@ -12,4 +12,4 @@ PGSERVICE=production-etl
 ENVD=/opt/backoffice/id3c-production/env.d
 
 
-0 4 * * * ubuntu export-prevalence | envdir $ENVD/aws/ aws s3 cp - s3://seattle-flu-study/prevalence.csv --content-type text/csv
+0 4 * * * ubuntu promjob "upload-prevalence" envdir $ENVD/aws/ upload-prevalence


### PR DESCRIPTION
Oops, we want to capture metrics on all jobs!  This was an oversight on
my part.  (Another good reason to switch to systemd timers, where we can
more automatically and ~transparently capture these metrics.)