### PR TITLE
Run Shellcheck on every push as part of CI

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,16 @@
+name: shellcheck
+
+on:
+  push:
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: install
+        run: sudo snap install --channel=edge --classic shellcheck
+
+      - name: check
+        run: ./dev/shellcheck

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,6 @@
+# Use of this file requires Shellcheck v0.7.0 or newer.
+#
+# SC2064 - We intentionally want variables to expand immediately within traps
+#          so the trap can not fail due to variable interpolation later.
+#
+disable=SC2064

--- a/bin/fatigue
+++ b/bin/fatigue
@@ -130,7 +130,7 @@ main() {
 
 # Print just the digest, skipping the filename.
 md5() {
-    md5sum "$@" | awk '{print $1}'
+    md5sum | awk '{print $1}'
 }
 
 # Print the MD5 digest of a state file, after masking.

--- a/bin/generate-and-upload-uw-retro-redcap-dets
+++ b/bin/generate-and-upload-uw-retro-redcap-dets
@@ -8,9 +8,6 @@
 
 set -euo pipefail
 
-# Absolute path to our containing repo
-base="$(cd "$(dirname "$0")/.."; pwd)"
-
 main() {
     for arg; do
         case "$arg" in
@@ -24,7 +21,7 @@ main() {
 }
 
 generate-redcap-dets() {
-    id3c redcap-det generate --api-url https://redcap.iths.org/api/ --project-id 19915 --since-date "`date +"%F %T" -d "25 hours ago"`" --include-incomplete
+    id3c redcap-det generate --api-url https://redcap.iths.org/api/ --project-id 19915 --since-date "$(date +"%F %T" -d "25 hours ago")" --include-incomplete
 }
 
 upload-to-id3c() {

--- a/bin/import-uw-retrospectives-to-redcap
+++ b/bin/import-uw-retrospectives-to-redcap
@@ -38,7 +38,7 @@ base="$(cd "$(dirname "$0")/.."; pwd)"
 
 redcap_api_token_name=REDCAP_API_TOKEN_redcap.iths.org_19915
 
-: ${CONFIG:="$base/etc/uw-retrospectives-manifest.yaml"}
+: "${CONFIG:="$base/etc/uw-retrospectives-manifest.yaml"}"
 
 main() {
     # Parse arguments.
@@ -48,7 +48,7 @@ main() {
     for arg; do
         case "$arg" in
             --import)
-                import=import-to-redcap
+                import="import-to-redcap"
                 shift;;
             --debug)
                 debug=1
@@ -72,7 +72,11 @@ main() {
     fi
 
     local previous_records="${1:-s3://fh-pi-bedford-t/seattleflu/uw-retrospectives-manifest.ndjson}"
-    local latest_records="$(mktemp -t "$(basename "$previous_records" .ndjson)"-XXXXXX.ndjson)"
+
+    # Declare separately from initializing to avoid masking failed exit
+    # statuses in $(…).
+    local latest_records; latest_records="$(mktemp -t "$(basename "$previous_records" .ndjson)"-XXXXXX.ndjson)"
+
     local new_records="${latest_records%.ndjson}-new.ndjson"
 
     if [[ $debug == 0 ]]; then

--- a/bin/promjob
+++ b/bin/promjob
@@ -11,7 +11,7 @@
 #
 set -euo pipefail
 
-: ${TEXTFILE_COLLECTOR_DIR:=/var/lib/prometheus/node-exporter}
+: "${TEXTFILE_COLLECTOR_DIR:=/var/lib/prometheus/node-exporter}"
 
 if [[ ! -w "$TEXTFILE_COLLECTOR_DIR" ]]; then
     echo "error: $TEXTFILE_COLLECTOR_DIR does not exist or is not writable" >&2
@@ -49,7 +49,7 @@ cronjob_end_time_seconds{name="$cronjob"} $ended
 
 # HELP cronjob_duration_seconds Duration of the cronjob in seconds.
 # TYPE cronjob_duration_seconds gauge
-cronjob_duration_seconds{name="$cronjob"} $(($ended - $started))
+cronjob_duration_seconds{name="$cronjob"} $((ended - started))
 
 # HELP cronjob_exit_status Exit status of the cronjob.
 # TYPE cronjob_exit_status gauge

--- a/bin/refresh-materialized-shipping-views
+++ b/bin/refresh-materialized-shipping-views
@@ -33,7 +33,7 @@ main() {
 refresh-materialized-views() {
 
     for view in "${shipping_views[@]}"; do
-        id3c refresh-materialized-view 'shipping' ${view} --commit
+        id3c refresh-materialized-view 'shipping' "$view" --commit
     done
 
 }

--- a/bin/upload-prevalence
+++ b/bin/upload-prevalence
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-: ${S3_DST:=s3://seattle-flu-study/prevalence.csv}
+: "${S3_DST:=s3://seattle-flu-study/prevalence.csv}"
 
 bin="$(dirname "$0")"
 

--- a/bin/upload-sch-retrospective-data-pulls
+++ b/bin/upload-sch-retrospective-data-pulls
@@ -10,8 +10,8 @@ shopt -s extglob
 # Change to the top-level of the backoffice checkout
 cd "$(dirname "$0")/.."
 
-: ${ID3C:=id3c-production}
-: ${id3c:=pipenv run id3c}
+: "${ID3C:=id3c-production}"
+: "${id3c:=pipenv run id3c}"
 
 export PIPENV_PIPFILE="$ID3C/Pipfile"
 

--- a/bin/uw-ehs-report/generate
+++ b/bin/uw-ehs-report/generate
@@ -12,9 +12,6 @@ set -euo pipefail
 
 bin="$(dirname "$0")"
 
-# Relative path to our containing repo
-base="$(dirname "$0")/../.."
-
 main() {
     for arg; do
         case "$arg" in

--- a/bin/wa-doh-linelists/export-id3c-hcov19-results
+++ b/bin/wa-doh-linelists/export-id3c-hcov19-results
@@ -9,11 +9,11 @@
 #
 set -euo pipefail
 
-if [ -z ${1+x} ]; then
+if [[ -z "${1:-}" ]]; then
     echo "A positional DATE argument (YYYY-MM-DD) is required."
     exit 1
 fi
 
-psql --quiet --no-align --tuples-only --set ON_ERROR_STOP= <<<"
-    \copy (select * from shipping.linelist_data_for_wa_doh_v1 where date_tested = '"$1"'::date) to pstdout with (format csv, header);
+psql --quiet --no-align --tuples-only --set ON_ERROR_STOP= --set date="$1" <<<"
+    copy (select * from shipping.linelist_data_for_wa_doh_v1 where date_tested = :'date') to stdout with (format csv, header);
 "

--- a/bin/wa-doh-linelists/generate
+++ b/bin/wa-doh-linelists/generate
@@ -11,7 +11,7 @@ set -euo pipefail
 # Change to the top-level of the backoffice checkout
 cd "$(dirname "$0")/../.."
 
-: ${ID3C:=id3c-production}
+: "${ID3C:=id3c-production}"
 
 export PIPENV_PIPFILE="$ID3C/Pipfile"
 

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,5 +1,12 @@
 # Dev tools
 
+## shellcheck
+
+Runs [Shellcheck](https://github.com/koalaman/shellcheck) on all
+version-controlled shell programs, to help identify and avoid some shell
+pitfalls.  This can be run by hand to check your work locally, but it will also
+be run automatically on every push as part of our CI.
+
 ## refresh-database
 
 As a quick start, you can refresh your local dev database with:

--- a/dev/refresh-database
+++ b/dev/refresh-database
@@ -23,10 +23,10 @@ PRODUCTION_PGDATABASE=production
 PRODUCTION_PGUSER=postgres
 
 # Default target database is our dev database
-: ${PGDATABASE:=seattleflu}
+: "${PGDATABASE:=seattleflu}"
 
 main() {
-    local workdir= pv=
+    local workdir="" pv=""
 
     for arg; do
         case "$arg" in
@@ -50,7 +50,7 @@ main() {
     if hash pv 2>/dev/null; then
         pv="pv --timer --rate --average-rate --bytes"
     else
-        pv=cat
+        pv="cat"
     fi
 
     log "Refreshing target database from production"
@@ -165,7 +165,7 @@ cd-to-workdir() {
 
 confirm-to-continue() {
     echo
-    read -e -p 'Press Y to continue, or any other key to abort: ' -n 1
+    read -r -e -p 'Press Y to continue, or any other key to abort: ' -n 1
 
     if [[ $REPLY =~ ^[Yy]$ ]]; then
         echo "Proceeding"
@@ -244,8 +244,8 @@ suppress-ignorable-errors() {
 
 elapsed-time() {
     local delta=$SECONDS
-    local minutes=$(($delta / 60))  # integer division
-    local seconds=$(($delta % 60))
+    local minutes=$((delta / 60))  # integer division
+    local seconds=$((delta % 60))
     printf "%dm%ds\n" $minutes $seconds
 }
 

--- a/dev/shellcheck
+++ b/dev/shellcheck
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -euo pipefail
+git grep -lEz '^#!/bin/(ba)?sh' | xargs -0 shellcheck "$@"


### PR DESCRIPTION
Helps identify and avoid common shell pitfalls. Addresses all issues reported.