### PR TITLE
Quiet down the UW retros import

### DIFF
--- a/bin/import-uw-retrospectives-to-redcap
+++ b/bin/import-uw-retrospectives-to-redcap
@@ -101,7 +101,7 @@ main() {
 
 parse-manifest() {
     id3c manifest parse-using-config "$CONFIG" \
-        | jq --compact-output 'select(.sample_origin | test("^(uwmc|hmc|nwh|phskc)_retro$"; "i"))'
+        | jq --compact-output 'select(.sample_origin | strings | test("^(uwmc|hmc|nwh|phskc)_retro$"; "i"))'
 }
 
 diff-manifests() {


### PR DESCRIPTION
jq was throwing error messages about not being able to test() the
.sample_origin when it is null.