### PR TITLE
refresh-materialized-shipping-views: delete extra leading space

### DIFF
--- a/bin/refresh-materialized-shipping-views
+++ b/bin/refresh-materialized-shipping-views
@@ -12,7 +12,7 @@ set -euo pipefail
 # They will get refreshed in the order listed.
 shipping_views=(
     "fhir_questionnaire_responses_v1"
-    " __uw_encounters"
+    "__uw_encounters"
     "scan_encounters_v1"
     )
 


### PR DESCRIPTION
The extra leading space in front of `__uw_encounters` started causing
errors due to the bash variable syntax change
in 74c8ead1a27bfa386148ab63d2e3dfb1b71b57a6.