### PR TITLE
return-of-results: use pagesize when fetching redcap records

### DIFF
--- a/bin/return-of-results/export-redcap-scan
+++ b/bin/return-of-results/export-redcap-scan
@@ -58,7 +58,7 @@ def main():
 
 
 def fetch_records(project):
-    for record in project.records(fields = FIELDS, raw = True):
+    for record in project.records(fields = FIELDS, raw = True, page_size = 5000):
         if not all(len(record[field]) for field in REQUIRED_FIELDS):
             continue
 

--- a/bin/return-of-results/export-redcap-sfs-classic
+++ b/bin/return-of-results/export-redcap-sfs-classic
@@ -114,7 +114,7 @@ def fetch_records(project) -> List[Dict[str, dict]]:
     if project.contacted_field:
         fields.add(project.contacted_field)
 
-    for record in project.records(fields = fields, raw = True):
+    for record in project.records(fields = fields, raw = True, page_size = 5000):
         if len(required_fields) > 0 and not all(len(record[field]) for field in required_fields):
             continue
 

--- a/bin/return-of-results/export-redcap-sfs-longitudinal
+++ b/bin/return-of-results/export-redcap-sfs-longitudinal
@@ -130,7 +130,7 @@ def fetch_enrollment_records(project) -> Dict[str, dict]:
     fields = [project.record_id_field, project.participant_first_name_field,
         project.participant_last_name_field, project.participant_birthdate_field]
 
-    for record in project.records(events = project.enrollment_event_names, fields = fields, raw = True):
+    for record in project.records(events = project.enrollment_event_names, fields = fields, raw = True, page_size = 5000):
         if not all(len(record[field]) for field in fields):
             continue
 
@@ -168,7 +168,7 @@ def fetch_encounter_records(project):
     if project.contacted_field:
         fields.add(project.contacted_field)
 
-    for record in project.records(events = project.encounter_event_names, fields = fields, raw = True):
+    for record in project.records(events = project.encounter_event_names, fields = fields, raw = True, page_size = 5000):
         if len(required_fields) > 0 and not any(len(record[field]) for field in required_fields):
             continue
 


### PR DESCRIPTION
Use the ID3C Redcap page_size param to fetch records in pages
instead of all at once for each Redcap project.

Fetching all the records at once was causing us to get 500 responses
on these requests with a message that "REDCap ran out of server memory"
responses from Redcap.

I'll start by setting page_size to 5000 for all the projects, which is
what we are currently using to fetch from HCT. We may need to tune it
later. This succeeded at the time of testing, but we will find out more
tonight, because we have more frequently been seeing the Redcap API
memory-related errors outside of business hours.