### PR TITLE
Update to populate-test-quota-sql to handle any input values

### DIFF
--- a/dev/populate-test-quota-sql.txt
+++ b/dev/populate-test-quota-sql.txt
@@ -21,6 +21,7 @@ end_hour int = 20;
 hour_interval int = 1;
 
 hourly_quota int;
+daily_quota_iterations int;
 current_hourly_quota int;
 plan_vs_actual_diff int;
 cur_day int = 0;
@@ -31,21 +32,25 @@ start_ts timestamp;
 end_ts timestamp;
 sql_text text;
 BEGIN
-	hourly_quota = daily_quota / round((end_hour - start_hour) / hour_interval::decimal);
-	plan_vs_actual_diff = (hourly_quota * (end_hour - start_hour)) - daily_quota;
+    daily_quota_iterations = ceil((end_hour - start_hour) / hour_interval::decimal);
+	daily_quota_iterations = case when daily_quota < daily_quota_iterations then daily_quota else daily_quota_iterations end;
+	
+	hourly_quota = daily_quota / daily_quota_iterations::decimal;
+    plan_vs_actual_diff = (hourly_quota * daily_quota_iterations) - daily_quota;
 
 	WHILE cur_day < num_days LOOP
 		cur_date = start_date::date + cur_day;
 		cur_hour = start_hour;
-		WHILE cur_hour < end_hour LOOP
+		WHILE daily_quota_iterations > 0 LOOP
 			start_ts = cur_date::text || ' '|| case when length(cur_hour::text) < 2 then ('0' || cur_hour::text) else cur_hour::text end || ':00:00';
 			end_ts = start_ts + interval '1h';
 
-			current_hourly_quota = case when cur_hour = (end_hour - 1) then (hourly_quota - plan_vs_actual_diff) else hourly_quota end;
+			current_hourly_quota = case when daily_quota_iterations = 1 then (hourly_quota - plan_vs_actual_diff) else hourly_quota end;
 			sql_text = 'insert into operations.test_quota (name, timespan, max) values (''uw'', tstzrange(''' || start_ts || ''', ''' || end_ts || ''' , ''(]''),' || current_hourly_quota || ');' ;
 			raise notice '%', sql_text;
 			EXECUTE sql_text;
 			cur_hour = cur_hour + hour_interval;
+			daily_quota_iterations = daily_quota_iterations - 1;
 		END LOOP;
 		cur_day = cur_day + 1;
 	END LOOP;


### PR DESCRIPTION
Continuation of 256f4e600cf46e00b2f6aac016d26ef652644381 to handle hourly intevals > 1
and cases where daily quota is less than the number of iterations generated by number of hours
divided by the hourly interval, both which could cause the total number of hourly quotas
inserted in any given day to be higher than the number being requested.