### PR TITLE
terminate-idle-sessions: Exclude postgres user from consideration

### DIFF
--- a/bin/terminate-idle-sessions
+++ b/bin/terminate-idle-sessions
@@ -23,7 +23,7 @@ psql --quiet --no-align --tuples-only --set ON_ERROR_STOP= <<<"
         select *, pg_terminate_backend(pid) as terminated
         from candidate_connections
         where idle_duration > interval '30 min'
-        and usename not in ('rdsadmin', 'metabase')
+        and usename not in ('postgres', 'rdsadmin', 'metabase')
         and usename not in (select rolname from pg_roles where rolsuper)
     )
 


### PR DESCRIPTION
This is the database "root" user, and should be excluded just like
"rdsadmin". We use "postgres" for `sqitch deploy`, which seems like it
can end up idle (or idle in a transaction) while it waits on a lock.