### PR TITLE
Add SSH creds to linelist crontab

### DIFF
--- a/bin/wa-doh-linelists/transform
+++ b/bin/wa-doh-linelists/transform
@@ -50,7 +50,7 @@ def put_file(linelist: pd.DataFrame, filename: str):
     if (proto == 'ssh' or proto == 'sftp'):
         filespec = fsspec.open(filename, mode='w',
             username=os.environ.get("DOH_USERNAME"),
-            pkey=os.environ.get("DOH_PRIVKEY_PATH"))
+            key_filename=os.environ.get("DOH_PRIVKEY_PATH"))
     elif (proto == 's3'):
         filespec = fsspec.open(filename, mode='w')
     elif (proto == 'file'):

--- a/crontabs/wa-doh-linelists
+++ b/crontabs/wa-doh-linelists
@@ -17,5 +17,9 @@ XDG_RUNTIME_DIR=/home/ubuntu/run
 # Directory to hold flock files
 FLOCK_DIR=/var/run/lock
 
+# SSH credentials for uploading to sft.wa.gov 
+DOH_USERNAME="doh-elff-NorthwestGenomicsCenterSCAN"
+DOH_PRIVKEY_PATH="/home/ubuntu/.ssh/sft_id_rsa"
+
 # Generate and upload the previous day's linelist data once a day at 6 A.M.
 0 6 * * * ubuntu promjob "wa-doh-linelists" chronic pipenv run envdir $ENVD/hutch envdir $ENVD/redcap /opt/backoffice/bin/wa-doh-linelists/generate --date $(date --date=yesterday --iso-8601=date) --output-dir "s3://fh-pi-bedford-t/seattleflu/public-health-reporting" --output-dir "ssh://sft.wa.gov" --upload-if-empty "s3://fh-pi-bedford-t/seattleflu/public-health-reporting"


### PR DESCRIPTION
Add SSH username & private key file to wa-doh-linelist crontab for
automated file upload to the state Department of Health. It was
previously manually entered for testing; now that we've got it
working, it can go in version control.

The full path to the key is specified because cron doesn't seem to
expand $HOME, causing errors.